### PR TITLE
fix(kit): `maskitoCaretGuard` doesn't work after focus on `<select />`

### DIFF
--- a/projects/kit/src/lib/plugins/caret-guard.ts
+++ b/projects/kit/src/lib/plugins/caret-guard.ts
@@ -12,7 +12,9 @@ export function maskitoCaretGuard(
         const document = element.ownerDocument;
         let isPointerDown = 0;
         const onPointerDown = (): number => isPointerDown++;
-        const onPointerUp = (): number => isPointerDown--;
+        const onPointerUp = (): void => {
+            isPointerDown = Math.max(--isPointerDown, 0);
+        };
 
         const listener = (): void => {
             if (getFocused(document) !== element) {
@@ -39,7 +41,7 @@ export function maskitoCaretGuard(
         };
 
         document.addEventListener('selectionchange', listener, {passive: true});
-        document.addEventListener('mousedown', onPointerDown, {passive: true});
+        element.addEventListener('mousedown', onPointerDown, {passive: true});
         document.addEventListener('mouseup', onPointerUp, {passive: true});
 
         return () => {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
1. Use Firefox or Safari

2. Run
```ts
import {ChangeDetectionStrategy, Component} from '@angular/core';
import {maskitoCaretGuard, maskitoNumberOptionsGenerator} from '@maskito/kit';

const numberOptions = maskitoNumberOptionsGenerator({
    postfix: `$`,
});

@Component({
    selector: 'test-doc-example-5',
    template: `
        <input
            value="100$"
            [maskito]="numberMask"
        />

        <select>
            <option>1</option>
            <option>2</option>
            <option>3</option>
        </select>
    `,
    changeDetection: ChangeDetectionStrategy.OnPush,
})
export class TestDocExample5 {
    readonly numberMask = {
        ...numberOptions,
        plugins: [
            ...numberOptions.plugins,
            maskitoCaretGuard(value => [0, value.length - 1]),
        ],
    };
}
```


https://github.com/taiga-family/maskito/assets/35179038/eed918cf-4ff5-4c35-a801-17ad8e4b037c


**See also:**
* Look into this [Stackblitz example](https://stackblitz.com/edit/native-select-mouse-events-bug?file=index.ts,index.html). Chrome, Firefox and Safari behave in different ways.
Repeat many times these actions: click on `<select />` + close dropdown via clicking outside.
* https://bugs.chromium.org/p/chromium/issues/detail?id=26017

## What is the new behavior?
Closes https://github.com/taiga-family/taiga-ui/issues/5233

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
