### PR TITLE
ci: drop old `perfectionist/sort-*` eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,10 +27,6 @@ module.exports = {
                 '@taiga-ui/experience/no-typeof': 'off',
                 '@typescript-eslint/naming-convention': 'off', // TODO
                 '@typescript-eslint/consistent-type-assertions': 'off',
-                'perfectionist/sort-interfaces': 'off',
-                'perfectionist/sort-enums': 'off',
-                'perfectionist/sort-object-types': 'off',
-                'perfectionist/sort-map-elements': 'off',
                 'no-irregular-whitespace': 'off',
                 'max-statements': 'off',
                 'no-restricted-syntax': 'off', // TODO


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
<img width="1030" alt="eslint-error" src="https://github.com/taiga-family/maskito/assets/35179038/e1553984-770d-4fa9-a45e-5263495a869b">

## What is the new behavior?
See:
* https://github.com/taiga-family/linters/pull/27
