### PR TITLE
fix(kit): `Number` should accept all types of spaces as interchangeable characters for `thousandSeparator`

### DIFF
--- a/projects/kit/src/lib/masks/number/processors/thousand-separator-postprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/thousand-separator-postprocessor.ts
@@ -24,6 +24,7 @@ export function createThousandSeparatorPostprocessor({
 
     const prefixReg = new RegExp(`^${escapeRegExp(prefix)}${CHAR_MINUS}?`);
     const postfixReg = new RegExp(`${escapeRegExp(postfix)}$`);
+    const isAllSpaces = (...chars: string[]): boolean => chars.every(x => /\s/.test(x));
 
     return ({value, selection}) => {
         const [integerPart, decimalPart = ''] = value.split(decimalSeparator);
@@ -43,8 +44,11 @@ export function createThousandSeparatorPostprocessor({
                     formattedValuePart.length &&
                     (formattedValuePart.length + 1) % 4 === 0;
 
-                if (char === thousandSeparator && isPositionForSeparator) {
-                    return char + formattedValuePart;
+                if (
+                    isPositionForSeparator &&
+                    (char === thousandSeparator || isAllSpaces(char, thousandSeparator))
+                ) {
+                    return thousandSeparator + formattedValuePart;
                 }
 
                 if (char === thousandSeparator && !isPositionForSeparator) {

--- a/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
+++ b/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
@@ -55,4 +55,14 @@ describe('Number (maskitoTransform)', () => {
             expect(maskitoTransform('−120 343', options)).toBe('−120.343');
         });
     });
+
+    it('should accept simple and non-breaking spaces as interchangeable characters for [thousandSeparator]', () => {
+        const options = maskitoNumberOptionsGenerator({
+            postfix: ' $',
+            thousandSeparator: ' ',
+        });
+
+        expect(maskitoTransform('45 001 $', options)).toBe('45 001 $'); // initialization phase
+        expect(maskitoTransform('45 001 $', options)).toBe('45 001 $'); // next user interaction
+    });
 });

--- a/projects/kit/src/lib/masks/number/utils/generate-mask-expression.ts
+++ b/projects/kit/src/lib/masks/number/utils/generate-mask-expression.ts
@@ -28,7 +28,7 @@ export function generateMaskExpression({
         ? `[${CHAR_MINUS}${pseudoMinuses.map(x => `\\${x}`).join('')}]?`
         : '';
     const integerPart = thousandSeparator
-        ? `[${digit}${escapeRegExp(thousandSeparator)}]*`
+        ? `[${digit}${escapeRegExp(thousandSeparator).replace(/\s/g, '\\s')}]*`
         : `[${digit}]*`;
     const decimalPart =
         precision > 0


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Relates to https://github.com/taiga-family/taiga-ui/issues/5388

```ts
const options = maskitoNumberOptionsGenerator({
    postfix: ' $',
    thousandSeparator: ' ', // non-breaking space!
});

const valueWithSimpleSpaces = '45 001 $';

// first one works fine
maskitoTransform(valueWithSimpleSpaces, options); // '45 001 $'

// it will return wrong value
maskitoTransform(valueWithSimpleSpaces, options); // '45 $'
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
