### PR TITLE
fix(kit): `Number` has broken zero padding when `decimalSeparator` equals to non-default value

### DIFF
--- a/projects/kit/src/lib/masks/number/processors/decimal-zero-padding-postprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/decimal-zero-padding-postprocessor.ts
@@ -26,7 +26,7 @@ export function createDecimalZeroPaddingPostprocessor({
     const trailingPostfixRegExp = new RegExp(`${escapeRegExp(postfix)}$`);
 
     return ({value, selection}) => {
-        if (Number.isNaN(maskitoParseNumber(value))) {
+        if (Number.isNaN(maskitoParseNumber(value, decimalSeparator))) {
             return {value, selection};
         }
 

--- a/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
+++ b/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
@@ -65,4 +65,22 @@ describe('Number (maskitoTransform)', () => {
         expect(maskitoTransform('45 001 $', options)).toBe('45 001 $'); // initialization phase
         expect(maskitoTransform('45 001 $', options)).toBe('45 001 $'); // next user interaction
     });
+
+    describe('`thousandSeparator` is equal to the item from `decimalPseudoSeparators` with zero padding', () => {
+        let options: MaskitoOptions = MASKITO_DEFAULT_OPTIONS;
+
+        beforeEach(() => {
+            options = maskitoNumberOptionsGenerator({
+                decimalSeparator: ',',
+                thousandSeparator: '.',
+                decimalPseudoSeparators: ['.', ','],
+                precision: 2,
+                decimalZeroPadding: true,
+            });
+        });
+
+        it('add dots and decimals (21.121.321,00)', () => {
+            expect(maskitoTransform('21121321', options)).toBe('21.121.321,00');
+        });
+    });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

```JavaScript
const options = maskitoNumberOptionsGenerator({
    decimalSeparator: ',',
    thousandSeparator: '.',
    decimalPseudoSeparators: ['.', ','],
    precision: 2,
    decimalZeroPadding: true,
});

const largeValue = '1000000';

// will return a value without zero padding
maskitoTransform(largeValue, options); // '1.000.000'
```

## What is the new behavior?

```JavaScript
const options = maskitoNumberOptionsGenerator({
    decimalSeparator: ',',
    thousandSeparator: '.',
    decimalPseudoSeparators: ['.', ','],
    precision: 2,
    decimalZeroPadding: true,
});

const largeValue = '1000000';

// will return a value with zero padding
maskitoTransform(largeValue, options); // '1.000.000,00'
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
