### PR TITLE
fix(kit): `PrefixPostprocessor` has problems with multi-character prefix

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/number/number-prefix-postfix.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/number/number-prefix-postfix.cy.ts
@@ -312,4 +312,24 @@ describe('Number | Prefix & Postfix', () => {
                 .should('have.prop', 'selectionEnd', 0);
         });
     });
+
+    describe('multi-character prefix "EUR " (no initial value & no caret guard)', () => {
+        beforeEach(() => {
+            cy.visit(DemoPath.Cypress);
+            cy.get('#multi-character-prefix input')
+                .focus()
+                .should('have.value', '')
+                .as('input');
+        });
+
+        ['E', 'U', 'R'].forEach(char => {
+            it(`Empty input => Type "${char} => Textfield's value is "EUR "`, () => {
+                cy.get('@input')
+                    .type(char)
+                    .should('have.value', 'EUR ')
+                    .should('have.prop', 'selectionStart', 'EUR '.length)
+                    .should('have.prop', 'selectionEnd', 'EUR '.length);
+            });
+        });
+    });
 });

--- a/projects/demo/src/pages/cypress/cypress.module.ts
+++ b/projects/demo/src/pages/cypress/cypress.module.ts
@@ -13,6 +13,7 @@ import {TestDocExample2} from './examples/2-native-max-length/component';
 import {TestDocExample3} from './examples/3-mirrored-prefix-postfix/component';
 import {TestDocExample4, TestPipe4} from './examples/4-runtime-postfix-changes/component';
 import {TestDocExample5} from './examples/5-react-async-predicate/angular-wrapper';
+import {TestDocExample6} from './examples/6-multi-character-prefix/component';
 
 @NgModule({
     imports: [
@@ -32,6 +33,7 @@ import {TestDocExample5} from './examples/5-react-async-predicate/angular-wrappe
         TestDocExample4,
         TestPipe4,
         TestDocExample5,
+        TestDocExample6,
     ],
     exports: [CypressDocPageComponent],
 })

--- a/projects/demo/src/pages/cypress/cypress.template.html
+++ b/projects/demo/src/pages/cypress/cypress.template.html
@@ -10,6 +10,8 @@
             <test-doc-example-4 id="runtime-postfix-changes"></test-doc-example-4>
 
             <test-doc-example-5 id="react-async-predicate"></test-doc-example-5>
+
+            <test-doc-example-6 id="multi-character-prefix"></test-doc-example-6>
         </div>
     </ng-template>
 </tui-doc-page>

--- a/projects/demo/src/pages/cypress/examples/6-multi-character-prefix/component.ts
+++ b/projects/demo/src/pages/cypress/examples/6-multi-character-prefix/component.ts
@@ -1,0 +1,20 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {MaskitoOptions} from '@maskito/core';
+import {maskitoNumberOptionsGenerator} from '@maskito/kit';
+
+@Component({
+    selector: 'test-doc-example-6',
+    template: `
+        <input
+            placeholder="Type 'E', 'U' or 'R' character"
+            value=""
+            [maskito]="numberMask"
+        />
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TestDocExample6 {
+    readonly numberMask: MaskitoOptions = maskitoNumberOptionsGenerator({
+        prefix: 'EUR ',
+    });
+}

--- a/projects/kit/src/lib/processors/prefix-postprocessor.ts
+++ b/projects/kit/src/lib/processors/prefix-postprocessor.ts
@@ -15,20 +15,18 @@ export function maskitoPrefixPostprocessorGenerator(
               }
 
               const [from, to] = selection;
-              const requiredPrefix = Array.from(prefix).reduce(
-                  (computedPrefix, char, i) => {
-                      const newValue = computedPrefix + value;
-
-                      return newValue[i] === char
-                          ? computedPrefix
-                          : computedPrefix + char;
-                  },
-                  '',
+              const prefixedValue = Array.from(prefix).reduce(
+                  (modifiedValue, char, i) =>
+                      modifiedValue[i] === char
+                          ? modifiedValue
+                          : modifiedValue.slice(0, i) + char + modifiedValue.slice(i),
+                  value,
               );
+              const addedCharsCount = prefixedValue.length - value.length;
 
               return {
-                  selection: [from + requiredPrefix.length, to + requiredPrefix.length],
-                  value: requiredPrefix + value,
+                  selection: [from + addedCharsCount, to + addedCharsCount],
+                  value: prefixedValue,
               };
           }
         : identity;

--- a/projects/kit/src/lib/processors/tests/prefix-postprocessor.spec.ts
+++ b/projects/kit/src/lib/processors/tests/prefix-postprocessor.spec.ts
@@ -1,4 +1,8 @@
+import {MaskitoPostprocessor} from '@maskito/core';
+
 import {maskitoPrefixPostprocessorGenerator} from '../prefix-postprocessor';
+
+type ElementState = ReturnType<MaskitoPostprocessor>;
 
 describe('maskitoPrefixPostprocessorGenerator', () => {
     const EMPTY_INPUT = {value: '', selection: [0, 0] as const};
@@ -67,6 +71,32 @@ describe('maskitoPrefixPostprocessorGenerator', () => {
                     {value: 'kg 123', selection: [2, 2]}, // before
                 ),
             ).toEqual({value: 'kg 123', selection: [2, 2]});
+        });
+
+        describe('Textfield is empty => Type any character from prefix', () => {
+            const process = (elementState: ElementState): ElementState =>
+                postprocessor(elementState, EMPTY_INPUT);
+
+            it('Empty input => type k (part of prefix) => kg |', () => {
+                expect(process({value: 'k', selection: [1, 1]})).toEqual({
+                    value: 'kg ',
+                    selection: [3, 3],
+                });
+            });
+
+            it('Empty input => type g (part of prefix) => kg |', () => {
+                expect(process({value: 'g', selection: [1, 1]})).toEqual({
+                    value: 'kg ',
+                    selection: [3, 3],
+                });
+            });
+
+            it('Empty input => type space (part of prefix) => kg |', () => {
+                expect(process({value: ' ', selection: [1, 1]})).toEqual({
+                    value: 'kg ',
+                    selection: [3, 3],
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
```ts
const options = maskitoNumberOptionsGenerator({
  prefix: 'EUR ',
});
```

1. Empty input
2. Type `U`

Textfield value is `URE                                            `.

Closes #595

## What is the new behaviour?
Textfield value is `EUR `.
