### PR TITLE
ci: fix prerender of page `https://maskito.dev/addons/phone/API`

### DIFF
--- a/scripts/generate-demo-routes-file.ts
+++ b/scripts/generate-demo-routes-file.ts
@@ -4,7 +4,7 @@ import {join} from 'path';
 import {DemoPath} from '../projects/demo/src/app/constants/demo-path';
 import {infoLog, SMALL_TAB_SYMBOL, titleLog} from './helpers/colored-log';
 
-const EXCEPTIONS = ['/', `${DemoPath.Angular}/Setup`];
+const EXCEPTIONS = ['/', `${DemoPath.Angular}/Setup`, `${DemoPath.PhonePackage}/API`];
 
 /**
  * This script is required for correct of `nx prerender demo` command.


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [X] Documentation content changes

## What is the current behaviour?
Open https://maskito.dev/addons/phone/API

<img width="842" alt="Screenshot 2023-11-23 at 16 50 24" src="https://github.com/taiga-family/maskito/assets/35179038/ce2d94ee-3514-4798-b29f-793493d57da8">

