### PR TITLE
ci: use `engine-strict=true` in `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 engine-strict=true
-lockfile-version=3
 loglevel=error

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-engine-strict=false
-lockfileVersion=2
-ignore-engines=true
+engine-strict=true
+lockfile-version=3
 loglevel=error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1970,11 +1970,11 @@
             }
         },
         "node_modules/@babel/core/node_modules/@babel/generator": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
-            "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
             "dependencies": {
-                "@babel/types": "^7.23.5",
+                "@babel/types": "^7.23.6",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -2118,13 +2118,13 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-            "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+            "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
             "dependencies": {
-                "@babel/compat-data": "^7.22.9",
-                "@babel/helper-validator-option": "^7.22.15",
-                "browserslist": "^4.21.9",
+                "@babel/compat-data": "^7.23.5",
+                "@babel/helper-validator-option": "^7.23.5",
+                "browserslist": "^4.22.2",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
@@ -2172,9 +2172,9 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.5.tgz",
-            "integrity": "sha512-QELlRWxSpgdwdJzSJn4WAhKC+hvw/AtHbbrIoncKHkhKKR/luAlKkgBDcri1EzWAo8f8VvYVryEHN4tax/V67A==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.6.tgz",
+            "integrity": "sha512-cBXU1vZni/CpGF29iTu4YRbOZt3Wat6zCoMDxRF1MayiEc4URxOj31tT65HUM0CRpMowA3HCJaAOVOUnMf96cw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -2541,13 +2541,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
-            "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
+            "integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
             "dependencies": {
                 "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.23.5",
-                "@babel/types": "^7.23.5"
+                "@babel/traverse": "^7.23.6",
+                "@babel/types": "^7.23.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2580,9 +2580,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
-            "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+            "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -2693,14 +2693,15 @@
             }
         },
         "node_modules/@babel/plugin-proposal-decorators": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.5.tgz",
-            "integrity": "sha512-6IsY8jOeWibsengGlWIezp7cuZEFzNlAghFpzh9wiZwhQ42/hRcPnY/QV9HJoKTlujupinSlnQPiEy/u2C1ZfQ==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.6.tgz",
+            "integrity": "sha512-D7Ccq9LfkBFnow3azZGJvZYgcfeqAw3I1e5LoTpj6UKIFQilh8yqXsIGcRIqbBdsPWIz+Ze7ZZfggSj62Qp+Fg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.23.5",
+                "@babel/helper-create-class-features-plugin": "^7.23.6",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-replace-supers": "^7.22.20",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
                 "@babel/plugin-syntax-decorators": "^7.23.3"
             },
@@ -3498,12 +3499,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.3.tgz",
-            "integrity": "sha512-X8jSm8X1CMwxmK878qsUGJRmbysKNbdpTv/O1/v0LuY/ZkZrng5WYiekYSdg9m09OTmDDUWeEDsTE+17WYbAZw==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
+            "integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4106,13 +4108,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.5.tgz",
-            "integrity": "sha512-2fMkXEJkrmwgu2Bsv1Saxgj30IXZdJ+84lQcKKI7sm719oXs0BBw2ZENKdJdR1PjWndgLCEBNXJOri0fk7RYQA==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.6.tgz",
+            "integrity": "sha512-6cBG5mBvUu4VUD04OHKnYzbuHNP8huDsD3EDqqpIpsswTDoqHCjLoHb6+QgsV1WsT2nipRqCPgxD3LXnEO7XfA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-create-class-features-plugin": "^7.23.5",
+                "@babel/helper-create-class-features-plugin": "^7.23.6",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/plugin-syntax-typescript": "^7.23.3"
             },
@@ -4383,19 +4385,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
-            "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
+            "integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
             "dependencies": {
                 "@babel/code-frame": "^7.23.5",
-                "@babel/generator": "^7.23.5",
+                "@babel/generator": "^7.23.6",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.23.5",
-                "@babel/types": "^7.23.5",
-                "debug": "^4.1.0",
+                "@babel/parser": "^7.23.6",
+                "@babel/types": "^7.23.6",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -4403,11 +4405,11 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/generator": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
-            "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
             "dependencies": {
-                "@babel/types": "^7.23.5",
+                "@babel/types": "^7.23.6",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -4441,9 +4443,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
-            "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.23.4",
                 "@babel/helper-validator-identifier": "^7.22.20",
@@ -5357,9 +5359,9 @@
             "dev": true
         },
         "node_modules/@cspell/dict-powershell": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.2.tgz",
-            "integrity": "sha512-IHfWLme3FXE7vnOmMncSBxOsMTdNWd1Vcyhag03WS8oANSgX8IZ+4lMI00mF0ptlgchf16/OU8WsV4pZfikEFw==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.3.tgz",
+            "integrity": "sha512-lEdzrcyau6mgzu1ie98GjOEegwVHvoaWtzQnm1ie4DyZgMr+N6D0Iyj1lzvtmt0snvsDFa5F2bsYzf3IMKcpcA==",
             "dev": true
         },
         "node_modules/@cspell/dict-public-licenses": {
@@ -8887,9 +8889,9 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.4.tgz",
-            "integrity": "sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.6.tgz",
+            "integrity": "sha512-kF1Zg62aPseQ11orDhFRw+aPG/eynNQtI+TyY+m33qJa2cJ5EEvza2P2BNTIA9E5MyqFABHEyY6CPHwgdy9aNg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.22.15",
@@ -8916,13 +8918,13 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/preset-env": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.5.tgz",
-            "integrity": "sha512-0d/uxVD6tFGWXGDSfyMD1p2otoaKmu6+GD+NfAx0tMaH+dxORnp7T9TaVQ6mKyya7iBtCIVxHjWT7MuzzM9z+A==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.6.tgz",
+            "integrity": "sha512-2XPn/BqKkZCpzYhUUNZ1ssXw7DcXfKQEjv/uXZUXgaebCMYmkEsfZ2yY+vv+xtXv50WmL5SGhyB6/xsWxIvvOQ==",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.23.5",
-                "@babel/helper-compilation-targets": "^7.22.15",
+                "@babel/helper-compilation-targets": "^7.23.6",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-validator-option": "^7.23.5",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
@@ -8962,7 +8964,7 @@
                 "@babel/plugin-transform-dynamic-import": "^7.23.4",
                 "@babel/plugin-transform-exponentiation-operator": "^7.23.3",
                 "@babel/plugin-transform-export-namespace-from": "^7.23.4",
-                "@babel/plugin-transform-for-of": "^7.23.3",
+                "@babel/plugin-transform-for-of": "^7.23.6",
                 "@babel/plugin-transform-function-name": "^7.23.3",
                 "@babel/plugin-transform-json-strings": "^7.23.4",
                 "@babel/plugin-transform-literals": "^7.23.3",
@@ -9033,9 +9035,9 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/runtime": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
-            "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+            "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -24081,9 +24083,9 @@
             }
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/@babel/runtime": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
-            "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+            "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the new behaviour?
```
➜  nvm use 16
Now using node v16.20.0 (npm v8.19.4)

➜  npm ci
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: maskito@1.9.0
npm ERR! notsup Not compatible with your version of node/npm: maskito@1.9.0
npm ERR! notsup Required: {"node":">= 18","npm":">= 9","yarn":"Please use npm instead of yarn to install dependencies"}
npm ERR! notsup Actual:   {"npm":"8.19.4","node":"v16.20.0"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/n.barsukov/.npm/_logs/2023-12-11T13_41_00_619Z-debug-0.log
```
