### PR TITLE
feat(core)!: merge `MaskitoElementPredicate` & `MaskitoElementPredicateAsync` into single type

### DIFF
--- a/projects/angular/src/lib/maskito.directive.ts
+++ b/projects/angular/src/lib/maskito.directive.ts
@@ -12,7 +12,6 @@ import {
     MASKITO_DEFAULT_ELEMENT_PREDICATE,
     MASKITO_DEFAULT_OPTIONS,
     MaskitoElementPredicate,
-    MaskitoElementPredicateAsync,
     MaskitoOptions,
 } from '@maskito/core';
 
@@ -24,8 +23,7 @@ export class MaskitoDirective implements OnDestroy, OnChanges {
     maskito: MaskitoOptions | null = MASKITO_DEFAULT_OPTIONS;
 
     @Input()
-    maskitoElement: MaskitoElementPredicate | MaskitoElementPredicateAsync =
-        MASKITO_DEFAULT_ELEMENT_PREDICATE;
+    maskitoElement: MaskitoElementPredicate = MASKITO_DEFAULT_ELEMENT_PREDICATE;
 
     constructor(
         @Inject(NgZone) private readonly ngZone: NgZone,

--- a/projects/core/src/index.ts
+++ b/projects/core/src/index.ts
@@ -5,7 +5,6 @@ export {
 export {Maskito} from './lib/mask';
 export {
     MaskitoElementPredicate,
-    MaskitoElementPredicateAsync,
     MaskitoMask,
     MaskitoMaskExpression,
     MaskitoOptions,

--- a/projects/core/src/lib/constants/default-element-predicate.ts
+++ b/projects/core/src/lib/constants/default-element-predicate.ts
@@ -1,4 +1,5 @@
 import {MaskitoElementPredicate} from '../types';
 
 export const MASKITO_DEFAULT_ELEMENT_PREDICATE: MaskitoElementPredicate = e =>
-    e.querySelector('input,textarea') || (e as HTMLInputElement | HTMLTextAreaElement);
+    e.querySelector<HTMLInputElement | HTMLTextAreaElement>('input,textarea') ||
+    (e as HTMLInputElement | HTMLTextAreaElement);

--- a/projects/core/src/lib/types/element-predicate.ts
+++ b/projects/core/src/lib/types/element-predicate.ts
@@ -1,8 +1,6 @@
 export type MaskitoElementPredicate = (
     element: HTMLElement,
-) => HTMLInputElement | HTMLTextAreaElement; // TODO: add `Promise<HTMLInputElement | HTMLTextAreaElement>`
-
-// TODO: delete in v2.0
-export type MaskitoElementPredicateAsync = (
-    element: HTMLElement,
-) => Promise<HTMLInputElement | HTMLTextAreaElement>;
+) =>
+    | HTMLInputElement
+    | HTMLTextAreaElement
+    | Promise<HTMLInputElement | HTMLTextAreaElement>;

--- a/projects/demo/src/pages/cypress/examples/1-predicate/component.ts
+++ b/projects/demo/src/pages/cypress/examples/1-predicate/component.ts
@@ -1,9 +1,5 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {
-    MaskitoElementPredicate,
-    MaskitoElementPredicateAsync,
-    MaskitoOptions,
-} from '@maskito/core';
+import {MaskitoElementPredicate, MaskitoOptions} from '@maskito/core';
 
 @Component({
     selector: 'test-doc-example-1',
@@ -41,6 +37,6 @@ export class TestDocExample1 {
     readonly namePredicate: MaskitoElementPredicate = element =>
         element.querySelectorAll('input')[1]!;
 
-    readonly asyncPredicate: MaskitoElementPredicateAsync = async element =>
+    readonly asyncPredicate: MaskitoElementPredicate = async element =>
         Promise.resolve(element.querySelectorAll('input')[0]!);
 }

--- a/projects/demo/src/pages/cypress/examples/5-react-async-predicate/react-app.tsx
+++ b/projects/demo/src/pages/cypress/examples/5-react-async-predicate/react-app.tsx
@@ -1,6 +1,5 @@
 // @ts-nocheck React & Vue Global JSX Types Conflicts
 // TODO: Check if it still required after upgrade Vue to 3.4 (https://github.com/vuejs/core/pull/7958)
-import type {MaskitoElementPredicateAsync} from '@maskito/core';
 import {MaskitoElementPredicate} from '@maskito/core';
 import {maskitoTimeOptionsGenerator} from '@maskito/kit';
 import {useMaskito} from '@maskito/react';
@@ -13,19 +12,19 @@ const options = maskitoTimeOptionsGenerator({
 const correctPredicate: MaskitoElementPredicate = host => host.querySelector('.real-input')!;
 const wrongPredicate: MaskitoElementPredicate = host => host.querySelector('input')!;
 
-const longCorrectPredicate: MaskitoElementPredicateAsync = host =>
+const longCorrectPredicate: MaskitoElementPredicate = host =>
     new Promise(resolve => {
         setTimeout(() => {
             resolve(correctPredicate(host));
         }, 2_000);
     });
 
-const longInvalidPredicate: MaskitoElementPredicateAsync = host =>
+const longInvalidPredicate: MaskitoElementPredicate = host =>
     new Promise(resolve => {
         setTimeout(() => resolve(wrongPredicate(host)), 7_000);
     });
 
-const fastValidPredicate: MaskitoElementPredicateAsync = host =>
+const fastValidPredicate: MaskitoElementPredicate = host =>
     new Promise(resolve => {
         setTimeout(() => resolve(correctPredicate(host)), 500);
     });

--- a/projects/demo/src/pages/frameworks/angular/examples/1-nested/component.ts
+++ b/projects/demo/src/pages/frameworks/angular/examples/1-nested/component.ts
@@ -22,5 +22,5 @@ export class NestedDocExample1 {
     };
 
     readonly predicate: MaskitoElementPredicate = element =>
-        element.querySelector('tui-input input')!;
+        element.querySelector<HTMLInputElement>('tui-input input')!;
 }

--- a/projects/react/src/lib/tests/elementPredicate.spec.tsx
+++ b/projects/react/src/lib/tests/elementPredicate.spec.tsx
@@ -1,9 +1,4 @@
-import {
-    MASKITO_DEFAULT_ELEMENT_PREDICATE,
-    MaskitoElementPredicate,
-    MaskitoElementPredicateAsync,
-    MaskitoOptions,
-} from '@maskito/core';
+import {MASKITO_DEFAULT_ELEMENT_PREDICATE, MaskitoElementPredicate, MaskitoOptions} from '@maskito/core';
 import {render, RenderResult, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -13,9 +8,9 @@ describe('@maskito/react | `elementPredicate` property', () => {
     const options: MaskitoOptions = {
         mask: /^\d+$/,
     };
-    let predicate: MaskitoElementPredicate | MaskitoElementPredicateAsync = MASKITO_DEFAULT_ELEMENT_PREDICATE;
+    let predicate: MaskitoElementPredicate = MASKITO_DEFAULT_ELEMENT_PREDICATE;
 
-    const correctPredicate: MaskitoElementPredicate = host => host.querySelector('.real-input')!;
+    const correctPredicate: MaskitoElementPredicate = host => host.querySelector<HTMLInputElement>('.real-input')!;
     const wrongPredicate: MaskitoElementPredicate = host => host.querySelector('input')!;
 
     function TestComponent({elementPredicate = predicate}) {

--- a/projects/react/src/lib/useMaskito.ts
+++ b/projects/react/src/lib/useMaskito.ts
@@ -3,7 +3,6 @@ import {
     MASKITO_DEFAULT_ELEMENT_PREDICATE,
     MASKITO_DEFAULT_OPTIONS,
     MaskitoElementPredicate,
-    MaskitoElementPredicateAsync,
     MaskitoOptions,
 } from '@maskito/core';
 import {RefCallback, useCallback, useRef, useState} from 'react';
@@ -33,7 +32,7 @@ export const useMaskito = ({
     elementPredicate = MASKITO_DEFAULT_ELEMENT_PREDICATE,
 }: {
     options?: MaskitoOptions;
-    elementPredicate?: MaskitoElementPredicate | MaskitoElementPredicateAsync;
+    elementPredicate?: MaskitoElementPredicate;
 } = {}): RefCallback<HTMLElement> => {
     const [hostElement, setHostElement] = useState<HTMLElement | null>(null);
     const [element, setElement] = useState<HTMLInputElement | HTMLTextAreaElement | null>(

--- a/projects/vue/src/lib/maskito.ts
+++ b/projects/vue/src/lib/maskito.ts
@@ -2,21 +2,17 @@ import {
     Maskito,
     MASKITO_DEFAULT_ELEMENT_PREDICATE,
     MaskitoElementPredicate,
-    MaskitoElementPredicateAsync,
     MaskitoOptions,
 } from '@maskito/core';
 import {ObjectDirective} from 'vue';
 
 const teardown = new Map<HTMLElement, Maskito>();
-const predicates = new Map<
-    HTMLElement,
-    MaskitoElementPredicate | MaskitoElementPredicateAsync
->();
+const predicates = new Map<HTMLElement, MaskitoElementPredicate>();
 
 async function update(
     element: HTMLElement,
     options: MaskitoOptions & {
-        elementPredicate?: MaskitoElementPredicate | MaskitoElementPredicateAsync;
+        elementPredicate?: MaskitoElementPredicate;
     },
 ): Promise<void> {
     const predicate = options.elementPredicate ?? MASKITO_DEFAULT_ELEMENT_PREDICATE;
@@ -36,7 +32,7 @@ async function update(
 export const maskito: ObjectDirective<
     HTMLElement,
     MaskitoOptions & {
-        elementPredicate?: MaskitoElementPredicate | MaskitoElementPredicateAsync;
+        elementPredicate?: MaskitoElementPredicate;
     }
 > = {
     unmounted: element => {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
**`@maskito/core` source code:**
```ts
export type MaskitoElementPredicate = (
    element: HTMLElement,
) => HTMLInputElement | HTMLTextAreaElement;

export type MaskitoElementPredicateAsync = (
    element: HTMLElement,
) => Promise<HTMLInputElement | HTMLTextAreaElement>;
```

___

**Your code:**
```ts
import {
    MaskitoElementPredicate,
    MaskitoElementPredicateAsync,
} from '@maskito/core';

const syncPredicate: MaskitoElementPredicate = element =>
    element.querySelectorAll('input')[1]!;

const asyncPredicate: MaskitoElementPredicateAsync = async element =>
    Promise.resolve(element.querySelectorAll('input')[1]!);
```

## What is the new behaviour?
**`@maskito/core` source code:**
```ts
export type MaskitoElementPredicate = (
    element: HTMLElement,
) =>
    | HTMLInputElement
    | HTMLTextAreaElement
    | Promise<HTMLInputElement | HTMLTextAreaElement>;
```

___

**Your code:**
```ts
import {MaskitoElementPredicate} from '@maskito/core';

const syncPredicate: MaskitoElementPredicate = element =>
    element.querySelectorAll('input')[1]!;

const asyncPredicate: MaskitoElementPredicate = async element =>
    Promise.resolve(element.querySelectorAll('input')[1]!);
```

Closes #607
