### PR TITLE
ci: add missed `taiga-family/ci/actions/setup/variables`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
       - run: npx nx run-many --target build --all --exclude=demo
 
@@ -20,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
       - run: npx nx build-gh-pages
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
       - run: npm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
       - run: npx nx build-gh-pages
       - uses: JamesIves/github-pages-deploy-action@v4.5.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 10
 
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
 
       - name: Mark demo-app directory for persist in cache
@@ -43,6 +44,7 @@ jobs:
     name: Kit / ${{ matrix.project }}
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
 
       - name: Download demo build from cache
@@ -68,6 +70,7 @@ jobs:
     name: Recipes
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
 
       - name: Download demo build from cache
@@ -91,6 +94,7 @@ jobs:
     name: Others
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
 
       - name: Download demo build from cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
       - run: npm run typecheck
 
@@ -13,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
       - run: npm run cspell -- --no-progress
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
       - run: npx nx run-many --target build --all --exclude=demo
       - run: npx nx run-many --target publish --all --exclude=demo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiga-family/ci/actions/setup/checkout@v1.45.2
+      - uses: taiga-family/ci/actions/setup/variables@v1.45.2
       - uses: taiga-family/ci/actions/setup/node@v1.45.2
       - run: npx nx run-many --target test --all --coverage
       - uses: codecov/codecov-action@v3.1.4


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
See this [job](https://github.com/taiga-family/maskito/actions/runs/7209213560/job/19639698592?pr=767):
```
>  NX   Invalid Cache Directory for Task "core:build"

   The local cache artifact in "/home/runner/work/maskito/maskito/.nx/cache/16217488490994067861" was not generated on this machine.
   As a result, the cache's content integrity cannot be confirmed, which may make cache restoration potentially unsafe.
   If your machine ID has changed since the artifact was cached, run "nx reset" to fix this issue.
   Read about the error and how to address it here: https://nx.dev/recipes/troubleshooting/unknown-local-cache
```

## What is the new behaviour?
