### PR TITLE
ci: run `auto-label.yml` only if `github.event.review.state == 'APPROVED'`

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   label-when-approved:
+    if: github.event.review.state == 'APPROVED'
     name: Label when approved
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the new behaviour?
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-when-a-pull-request-is-approved

<img width="755" alt="Screenshot 2023-12-15 at 11 02 44" src="https://github.com/taiga-family/maskito/assets/35179038/87cf30cc-8df2-43f1-a563-f6ab65c74338">
