### PR TITLE
feat(kit)!: delete deprecated `separator` for `DateRange` (use use `dateSeparator` instead)

### DIFF
--- a/projects/demo/src/pages/kit/date-range/date-range-mask-doc.component.ts
+++ b/projects/demo/src/pages/kit/date-range/date-range-mask-doc.component.ts
@@ -67,8 +67,6 @@ export class DateRangeMaskDocComponent implements GeneratorOptions {
     ];
 
     mode: MaskitoDateMode = this.modeOptions[0];
-    // TODO: drop in v2.0
-    separator = '.';
     minStr = this.minMaxOptions[0];
     maxStr = this.minMaxOptions[1];
     min = new Date(this.minStr);

--- a/projects/demo/src/pages/kit/date-range/date-range-mask-doc.template.html
+++ b/projects/demo/src/pages/kit/date-range/date-range-mask-doc.template.html
@@ -17,7 +17,7 @@
                 Use
                 <code>mode</code>
                 and
-                <code>separator</code>
+                <code>dateSeparator</code>
                 parameters to get a mask with a locale specific representation of dates.
             </ng-template>
             <date-range-mask-doc-example-1></date-range-mask-doc-example-1>
@@ -180,22 +180,6 @@
                 (documentationPropertyValueChange)="updateOptions()"
             >
                 Maximal length of the range
-            </ng-template>
-
-            <ng-template
-                documentationPropertyMode="input"
-                documentationPropertyName="separator"
-                [documentationPropertyDeprecated]="true"
-            >
-                Use
-                <code>dateSeparator</code>
-                instead.
-
-                <p>
-                    <strong>Default:</strong>
-                    <code>.</code>
-                    (dot).
-                </p>
             </ng-template>
         </tui-doc-documentation>
     </ng-template>

--- a/projects/kit/src/lib/masks/date-range/date-range-mask.ts
+++ b/projects/kit/src/lib/masks/date-range/date-range-mask.ts
@@ -13,20 +13,14 @@ import {createSwapDatesPostprocessor} from './processors/swap-dates-postprocesso
 
 export function maskitoDateRangeOptionsGenerator({
     mode,
-    separator = '.',
     min,
     max,
     minLength,
     maxLength,
-    dateSeparator = separator,
+    dateSeparator = '.',
     rangeSeparator = `${CHAR_NO_BREAK_SPACE}${CHAR_EN_DASH}${CHAR_NO_BREAK_SPACE}`,
 }: {
     mode: MaskitoDateMode;
-    /**
-     * @deprecated use `dateSeparator` instead
-     * TODO: drop in v2.0
-     */
-    separator?: string;
     min?: Date;
     max?: Date;
     minLength?: Partial<MaskitoDateSegments<number>>;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
```ts
import {maskitoDateRangeOptionsGenerator} from '@maskito/kit';

const options = maskitoDateRangeOptionsGenerator({
    mode: 'mm/dd/yyyy',
    separator: '/', // <-------- deprecated
    rangeSeparator: ' ~ ',
});
```

## What is the new behaviour?
```ts
import {maskitoDateRangeOptionsGenerator} from '@maskito/kit';

const options = maskitoDateRangeOptionsGenerator({
    mode: 'mm/dd/yyyy',
    dateSeparator: '/',
    rangeSeparator: ' ~ ',
});
```
