### PR TITLE
[WIP] feat(core)!: preprocessors have new improved version of the 2nd argument

### DIFF
--- a/projects/core/src/index.ts
+++ b/projects/core/src/index.ts
@@ -11,6 +11,7 @@ export {
     MaskitoPlugin,
     MaskitoPostprocessor,
     MaskitoPreprocessor,
+    MaskitoPreprocessorMetadata,
 } from './lib/types';
 export {
     maskitoInitialCalibrationPlugin,

--- a/projects/core/src/lib/types/mask-processors.ts
+++ b/projects/core/src/lib/types/mask-processors.ts
@@ -1,11 +1,17 @@
 import {ElementState} from './element-state';
+import {TypedInputEvent} from './typed-input-event';
+
+export interface MaskitoPreprocessorMetadata {
+    readonly eventName: 'beforeinput' | 'compositionend' | 'input';
+    readonly inputType: TypedInputEvent['inputType'] | '';
+}
 
 export type MaskitoPreprocessor = (
     _: {
         elementState: ElementState;
         data: string;
     },
-    actionType: 'deleteBackward' | 'deleteForward' | 'insert' | 'validation',
+    metadata: MaskitoPreprocessorMetadata,
 ) => {
     elementState: ElementState;
     data?: string;

--- a/projects/core/src/lib/types/typed-input-event.ts
+++ b/projects/core/src/lib/types/typed-input-event.ts
@@ -1,4 +1,5 @@
 export interface TypedInputEvent extends InputEvent {
+    type: 'beforeinput' | 'input';
     inputType:
         | 'deleteByCut' // Ctrl (Command) + X
         | 'deleteContentBackward' // Backspace

--- a/projects/core/src/lib/utils/test/pipe.spec.ts
+++ b/projects/core/src/lib/utils/test/pipe.spec.ts
@@ -1,8 +1,18 @@
-import {ElementState, MaskitoPostprocessor, MaskitoPreprocessor} from '../../types';
+import {
+    ElementState,
+    MaskitoPostprocessor,
+    MaskitoPreprocessor,
+    MaskitoPreprocessorMetadata,
+} from '../../types';
 import {maskitoPipe} from '../pipe';
 
 describe('maskitoPipe', () => {
     describe('Preprocessor', () => {
+        const INSERT: MaskitoPreprocessorMetadata = {
+            eventName: 'beforeinput',
+            inputType: 'insertText',
+        };
+
         const preprocessorData: Parameters<MaskitoPreprocessor>[0] = {
             elementState: {value: '2', selection: [2, 2]},
             data: '0',
@@ -33,7 +43,7 @@ describe('maskitoPipe', () => {
             expect(
                 maskitoPipe([add3ToData, add0ToValue, add5ToData])(
                     preprocessorData,
-                    'insert',
+                    INSERT,
                 ),
             ).toEqual({
                 elementState: {value: '20', selection: [2, 2]},
@@ -44,14 +54,14 @@ describe('maskitoPipe', () => {
         describe('Order matters', () => {
             it('for `elementState`', () => {
                 expect(
-                    maskitoPipe([add0ToValue, add1ToValue])(preprocessorData, 'insert'),
+                    maskitoPipe([add0ToValue, add1ToValue])(preprocessorData, INSERT),
                 ).toEqual({
                     elementState: {value: '201', selection: [2, 2]},
                     data: '0',
                 });
 
                 expect(
-                    maskitoPipe([add1ToValue, add0ToValue])(preprocessorData, 'insert'),
+                    maskitoPipe([add1ToValue, add0ToValue])(preprocessorData, INSERT),
                 ).toEqual({
                     elementState: {value: '210', selection: [2, 2]},
                     data: '0',
@@ -60,14 +70,14 @@ describe('maskitoPipe', () => {
 
             it('for `data`', () => {
                 expect(
-                    maskitoPipe([add3ToData, add5ToData])(preprocessorData, 'insert'),
+                    maskitoPipe([add3ToData, add5ToData])(preprocessorData, INSERT),
                 ).toEqual({
                     elementState: {value: '2', selection: [2, 2]},
                     data: '035',
                 });
 
                 expect(
-                    maskitoPipe([add5ToData, add3ToData])(preprocessorData, 'insert'),
+                    maskitoPipe([add5ToData, add3ToData])(preprocessorData, INSERT),
                 ).toEqual({
                     elementState: {value: '2', selection: [2, 2]},
                     data: '053',
@@ -78,7 +88,7 @@ describe('maskitoPipe', () => {
                 expect(
                     maskitoPipe([add5ToData, add0ToValue, add3ToData, add1ToValue])(
                         preprocessorData,
-                        'insert',
+                        INSERT,
                     ),
                 ).toEqual({
                     elementState: {value: '201', selection: [2, 2]},
@@ -170,17 +180,21 @@ describe('maskitoPipe', () => {
 
     describe('Readonly arguments are passed to all processors', () => {
         const elementState: ElementState = {value: '', selection: [0, 0]};
+        const deleteEventMeta: MaskitoPreprocessorMetadata = {
+            eventName: 'beforeinput',
+            inputType: 'deleteContentBackward',
+        };
 
         it('Preprocessor', () => {
             const checkActionType: MaskitoPreprocessor = (data, actionType) => {
-                expect(actionType).toBe('deleteBackward');
+                expect(actionType).toEqual(deleteEventMeta);
 
                 return data;
             };
 
             maskitoPipe([checkActionType, checkActionType, checkActionType])(
                 {elementState, data: ''},
-                'deleteBackward',
+                deleteEventMeta,
             );
         });
 

--- a/projects/core/src/lib/utils/transform.ts
+++ b/projects/core/src/lib/utils/transform.ts
@@ -1,17 +1,26 @@
 import {MaskModel} from '../classes';
 import {MASKITO_DEFAULT_OPTIONS} from '../constants';
-import {ElementState, MaskitoOptions} from '../types';
+import {ElementState, MaskitoOptions, MaskitoPreprocessorMetadata} from '../types';
 import {maskitoPipe} from './pipe';
 
-export function maskitoTransform(value: string, maskitoOptions: MaskitoOptions): string;
+export function maskitoTransform(
+    value: string,
+    maskitoOptions: MaskitoOptions,
+    _internal?: MaskitoPreprocessorMetadata,
+): string;
 export function maskitoTransform(
     state: ElementState,
     maskitoOptions: MaskitoOptions,
+    _internal?: MaskitoPreprocessorMetadata,
 ): ElementState;
 
 export function maskitoTransform(
     valueOrState: ElementState | string,
     maskitoOptions: MaskitoOptions,
+    preprocessorMetadata: MaskitoPreprocessorMetadata = {
+        eventName: 'input',
+        inputType: 'insertText',
+    },
 ): ElementState | string {
     const options: Required<MaskitoOptions> = {
         ...MASKITO_DEFAULT_OPTIONS,
@@ -26,7 +35,7 @@ export function maskitoTransform(
 
     const {elementState} = preprocessor(
         {elementState: initialElementState, data: ''},
-        'validation',
+        preprocessorMetadata,
     );
     const maskModel = new MaskModel(elementState, options);
     const {value, selection} = postprocessor(maskModel, initialElementState);

--- a/projects/kit/src/lib/masks/number/processors/non-removable-chars-deletion-preprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/non-removable-chars-deletion-preprocessor.ts
@@ -16,7 +16,7 @@ export function createNonRemovableCharsDeletionPreprocessor({
     thousandSeparator: string;
     decimalZeroPadding: boolean;
 }): MaskitoPreprocessor {
-    return ({elementState, data}, actionType) => {
+    return ({elementState, data}, {eventName, inputType}) => {
         const {value, selection} = elementState;
         const [from, to] = selection;
         const selectedCharacters = value.slice(from, to);
@@ -29,7 +29,8 @@ export function createNonRemovableCharsDeletionPreprocessor({
             Boolean(selectedCharacters.match(/^0+$/gi));
 
         if (
-            (actionType !== 'deleteBackward' && actionType !== 'deleteForward') ||
+            eventName !== 'beforeinput' ||
+            !inputType.includes('delete') ||
             (!nonRemovableSeparators.includes(selectedCharacters) &&
                 !areNonRemovableZeroesSelected)
         ) {
@@ -42,7 +43,7 @@ export function createNonRemovableCharsDeletionPreprocessor({
         return {
             elementState: {
                 value,
-                selection: actionType === 'deleteForward' ? [to, to] : [from, from],
+                selection: inputType.includes('Forward') ? [to, to] : [from, from],
             },
             data,
         };

--- a/projects/kit/src/lib/masks/number/processors/tests/not-empty-integer-part-preprocessor.spec.ts
+++ b/projects/kit/src/lib/masks/number/processors/tests/not-empty-integer-part-preprocessor.spec.ts
@@ -1,8 +1,15 @@
+import {MaskitoPreprocessorMetadata} from '@maskito/core';
+
 import {createNotEmptyIntegerPartPreprocessor} from '../not-empty-integer-part-preprocessor';
 
 const EMPTY_ELEMENT_STATE = {
     value: '',
     selection: [0, 0] as const,
+};
+
+const INSERT: MaskitoPreprocessorMetadata = {
+    eventName: 'beforeinput',
+    inputType: 'insertText',
 };
 
 describe('createNotEmptyIntegerPartPreprocessor', () => {
@@ -19,7 +26,7 @@ describe('createNotEmptyIntegerPartPreprocessor', () => {
                         elementState: EMPTY_ELEMENT_STATE,
                         data: 'a,',
                     },
-                    'insert',
+                    INSERT,
                 ),
             ).toEqual({
                 elementState: EMPTY_ELEMENT_STATE,
@@ -34,7 +41,7 @@ describe('createNotEmptyIntegerPartPreprocessor', () => {
                         elementState: EMPTY_ELEMENT_STATE,
                         data: 'aaa1aaa,',
                     },
-                    'insert',
+                    INSERT,
                 ),
             ).toEqual({
                 elementState: EMPTY_ELEMENT_STATE,
@@ -49,7 +56,7 @@ describe('createNotEmptyIntegerPartPreprocessor', () => {
                         elementState: EMPTY_ELEMENT_STATE,
                         data: ',3123',
                     },
-                    'insert',
+                    INSERT,
                 ),
             ).toEqual({
                 elementState: EMPTY_ELEMENT_STATE,
@@ -64,7 +71,7 @@ describe('createNotEmptyIntegerPartPreprocessor', () => {
                         elementState: EMPTY_ELEMENT_STATE,
                         data: 'aaa0aaa,3123',
                     },
-                    'insert',
+                    INSERT,
                 ),
             ).toEqual({
                 elementState: EMPTY_ELEMENT_STATE,

--- a/projects/kit/src/lib/masks/time/processors/max-validation-preprocessor.ts
+++ b/projects/kit/src/lib/masks/time/processors/max-validation-preprocessor.ts
@@ -20,7 +20,7 @@ export function createMaxValidationPreprocessor(
 
         const {value, selection} = elementState;
 
-        if (eventName === 'input' || eventName === 'compositionend') {
+        if (eventName !== 'beforeinput') {
             const {validatedTimeString, updatedTimeSelection} = validateTimeString({
                 timeString: value,
                 paddedMaxValues,

--- a/projects/kit/src/lib/masks/time/processors/max-validation-preprocessor.ts
+++ b/projects/kit/src/lib/masks/time/processors/max-validation-preprocessor.ts
@@ -13,14 +13,14 @@ export function createMaxValidationPreprocessor(
         `[^\\d${TIME_FIXED_CHARACTERS.map(escapeRegExp).join('')}]+`,
     );
 
-    return ({elementState, data}, actionType) => {
-        if (actionType === 'deleteBackward' || actionType === 'deleteForward') {
+    return ({elementState, data}, {eventName, inputType}) => {
+        if (eventName === 'beforeinput' && inputType.includes('delete')) {
             return {elementState, data};
         }
 
         const {value, selection} = elementState;
 
-        if (actionType === 'validation') {
+        if (eventName === 'input' || eventName === 'compositionend') {
             const {validatedTimeString, updatedTimeSelection} = validateTimeString({
                 timeString: value,
                 paddedMaxValues,

--- a/projects/kit/src/lib/masks/time/processors/tests/max-validation-preprocessor.spec.ts
+++ b/projects/kit/src/lib/masks/time/processors/tests/max-validation-preprocessor.spec.ts
@@ -14,7 +14,10 @@ describe('createMaxValidationPreprocessor', () => {
                     },
                     data,
                 },
-                'insert',
+                {
+                    eventName: 'beforeinput',
+                    inputType: 'insertFromPaste',
+                },
             ).data || '';
 
         it('All time segments valid', () => {
@@ -30,7 +33,7 @@ describe('createMaxValidationPreprocessor', () => {
         });
     });
 
-    describe('Dropping text inside with a pointer / browser autofill', () => {
+    describe('Browser autofill', () => {
         const process = (value: string): string =>
             processor(
                 {
@@ -40,7 +43,7 @@ describe('createMaxValidationPreprocessor', () => {
                     },
                     data: '',
                 },
-                'validation',
+                {eventName: 'input', inputType: 'insertText'},
             ).elementState.value;
 
         it('All time segments valid', () => {

--- a/projects/kit/src/lib/processors/tests/normalize-date-preprocessor.spec.ts
+++ b/projects/kit/src/lib/processors/tests/normalize-date-preprocessor.spec.ts
@@ -100,7 +100,7 @@ function getCheckFunction(
 
         const {data} = preprocessor(
             {elementState: EMPTY_INPUT, data: insertedCharacters},
-            'insert',
+            {eventName: 'beforeinput', inputType: 'insertText'},
         );
 
         expect(data).toEqual(expectedValue);

--- a/projects/kit/src/lib/processors/tests/valid-date-preprocessor.spec.ts
+++ b/projects/kit/src/lib/processors/tests/valid-date-preprocessor.spec.ts
@@ -12,7 +12,7 @@ describe('createValidDatePreprocessor', () => {
         const check = (insertedCharacters: string, expectedValue: string): void => {
             const {data} = preprocessor(
                 {elementState: EMPTY_INPUT, data: insertedCharacters},
-                'insert',
+                {eventName: 'beforeinput', inputType: 'insertText'},
             );
 
             expect(data).toEqual(expectedValue);

--- a/projects/kit/src/lib/processors/tests/with-placeholder.spec.ts
+++ b/projects/kit/src/lib/processors/tests/with-placeholder.spec.ts
@@ -16,7 +16,7 @@ describe('maskitoWithPlaceholder("dd/mm/yyyy")', () => {
                     },
                     data: '',
                 },
-                'insert',
+                {eventName: 'beforeinput', inputType: 'insertText'},
             );
 
             expect(elementState.value).toBe(valueAfter);

--- a/projects/kit/src/lib/processors/zero-placeholders-preprocessor.ts
+++ b/projects/kit/src/lib/processors/zero-placeholders-preprocessor.ts
@@ -1,7 +1,7 @@
 import {MaskitoPreprocessor} from '@maskito/core';
 
 export function createZeroPlaceholdersPreprocessor(): MaskitoPreprocessor {
-    return ({elementState}, actionType) => {
+    return ({elementState}, {eventName, inputType}) => {
         const {value, selection} = elementState;
 
         if (!value || isLastChar(value, selection)) {
@@ -13,7 +13,10 @@ export function createZeroPlaceholdersPreprocessor(): MaskitoPreprocessor {
         const zeroes = value.slice(from, to).replace(/\d/g, '0');
         const newValue = value.slice(0, from) + zeroes + value.slice(to);
 
-        if (actionType === 'validation' || (actionType === 'insert' && from === to)) {
+        if (
+            eventName !== 'beforeinput' ||
+            (inputType.includes('insert') && from === to)
+        ) {
             return {
                 elementState: {selection, value: newValue},
             };
@@ -22,7 +25,8 @@ export function createZeroPlaceholdersPreprocessor(): MaskitoPreprocessor {
         return {
             elementState: {
                 selection:
-                    actionType === 'deleteBackward' || actionType === 'insert'
+                    (inputType.includes('delete') && inputType.includes('Backward')) ||
+                    inputType.includes('insert')
                         ? [from, from]
                         : [to, to],
                 value: newValue,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- [X] Feature

## What is the current behaviour?
```ts
import {MaskitoPreprocessor} from '@maskito/core';

const myPreprocessor: MaskitoPreprocessor = (
    {elementState, data},
    actionType
) => {
    console.log(actionType); // 'deleteBackward' | 'deleteForward' | 'insert' | 'validation';

    return {elementState, data};
}
```

## What is the new behaviour?

```ts
import {MaskitoPreprocessor} from '@maskito/core';

const myPreprocessor: MaskitoPreprocessor = (
    {elementState, data},
    {eventName, inputType},
) => {
    console.log(eventName); // 'beforeinput' | 'input' | 'compositionend'

    /**
     * For a complete list of the available input types, see the W3C spec:
     * https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes
     * ___
     * If `eventName` === 'compositionend' => `inputType` equals to empty string
     */
    console.log(inputType); // 'insertFromDrop' | 'insertFromPaste' | 'deleteContentBackward' | '...';

    return {elementState, data};
}
```

<div id="migration"></div>

## Migration Guide
* Previous `actionType` === `validation` equals to the new `eventName` !== `beforeinput`
```diff
- actionType === 'validation'
+ eventName !== 'beforeinput'
```

* Previous `actionType` === `insert` equals to the new `inputType` which contains `insert`-word: 
```diff
- actionType === 'insert'
+ eventName === 'beforeinput' && inputType.includes('insert')
```

* Previous `actionType` === `deleteBackward` equals to the new `inputType` which contains `delete` and `Backward` words: 
```diff
- actionType === 'deleteBackward'
+ eventName === 'beforeinput' && inputType.includes('delete') && inputType.includes('Backward')
```

* Previous `actionType` === `deleteForward` equals to the new `inputType` which contains `delete` and `Forward` words: 
```diff
- actionType === 'deleteBackward'
+ eventName === 'beforeinput' && inputType.includes('delete') && inputType.includes('Forward')
```
