### PR TITLE
fix: add `{bubbles:true}` for `input` events inside all built-in plugins to support `ReactSyntheticEvent` 

### DIFF
--- a/projects/core/src/index.ts
+++ b/projects/core/src/index.ts
@@ -15,5 +15,6 @@ export {
 export {
     maskitoInitialCalibrationPlugin,
     maskitoPipe,
+    maskitoSetElementValue,
     maskitoTransform,
 } from './lib/utils';

--- a/projects/core/src/index.ts
+++ b/projects/core/src/index.ts
@@ -15,6 +15,6 @@ export {
 export {
     maskitoInitialCalibrationPlugin,
     maskitoPipe,
-    maskitoSetElementValue,
     maskitoTransform,
+    maskitoUpdateElement,
 } from './lib/utils';

--- a/projects/core/src/lib/utils/dom/set-element-value.ts
+++ b/projects/core/src/lib/utils/dom/set-element-value.ts
@@ -1,0 +1,28 @@
+/**
+ * Sets value to element, and dispatches input event
+ *
+ * @example
+ * maskitoSetElementValue(input, newValue);
+ *
+ * @see {@link https://github.com/taiga-family/maskito/issues/804 issue}
+ *
+ * @return void
+ */
+export function maskitoSetElementValue(
+    element: HTMLInputElement | HTMLTextAreaElement,
+    value: string,
+): void {
+    element.value = value;
+    element.dispatchEvent(
+        new Event(
+            'input',
+            /**
+             * React handles this event only on bubbling phase
+             *
+             * here is the list of events that are processed in the capture stage, others are processed in the bubbling stage
+             * https://github.com/facebook/react/blob/cb2439624f43c510007f65aea5c50a8bb97917e4/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js#L222
+             */
+            {bubbles: true},
+        ),
+    );
+}

--- a/projects/core/src/lib/utils/dom/update-element.ts
+++ b/projects/core/src/lib/utils/dom/update-element.ts
@@ -1,18 +1,30 @@
+import {ElementState} from '../../types';
+
 /**
  * Sets value to element, and dispatches input event
+ * if you passed ELementState, it also sets selection range
  *
  * @example
- * maskitoSetElementValue(input, newValue);
+ * maskitoUpdateElement(input, newValue);
+ * maskitoUpdateElement(input, elementState);
  *
  * @see {@link https://github.com/taiga-family/maskito/issues/804 issue}
  *
  * @return void
  */
-export function maskitoSetElementValue(
+export function maskitoUpdateElement(
     element: HTMLInputElement | HTMLTextAreaElement,
-    value: string,
+    valueOrElementState: ElementState | string,
 ): void {
-    element.value = value;
+    if (typeof valueOrElementState === 'string') {
+        element.value = valueOrElementState;
+    } else {
+        const [from, to] = valueOrElementState.selection;
+
+        element.value = valueOrElementState.value;
+        element.setSelectionRange?.(from, to);
+    }
+
     element.dispatchEvent(
         new Event(
             'input',

--- a/projects/core/src/lib/utils/index.ts
+++ b/projects/core/src/lib/utils/index.ts
@@ -1,6 +1,6 @@
 export * from './dom/event-listener';
 export * from './dom/history-events';
-export * from './dom/set-element-value';
+export * from './dom/update-element';
 export * from './element-states-equality';
 export * from './get-line-selection';
 export * from './get-not-empty-selection';

--- a/projects/core/src/lib/utils/index.ts
+++ b/projects/core/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './dom/event-listener';
 export * from './dom/history-events';
+export * from './dom/set-element-value';
 export * from './element-states-equality';
 export * from './get-line-selection';
 export * from './get-not-empty-selection';

--- a/projects/core/src/lib/utils/initial-calibration-plugin.ts
+++ b/projects/core/src/lib/utils/initial-calibration-plugin.ts
@@ -1,5 +1,5 @@
 import {MaskitoOptions, MaskitoPlugin} from '../types';
-import {maskitoSetElementValue} from './dom/set-element-value';
+import {maskitoUpdateElement} from './dom/update-element';
 import {maskitoTransform} from './transform';
 
 export function maskitoInitialCalibrationPlugin(
@@ -9,10 +9,9 @@ export function maskitoInitialCalibrationPlugin(
         const from = element.selectionStart || 0;
         const to = element.selectionEnd || 0;
 
-        maskitoSetElementValue(
-            element,
-            maskitoTransform(element.value, customOptions || options),
-        );
-        element.setSelectionRange?.(from, to);
+        maskitoUpdateElement(element, {
+            value: maskitoTransform(element.value, customOptions || options),
+            selection: [from, to],
+        });
     };
 }

--- a/projects/core/src/lib/utils/initial-calibration-plugin.ts
+++ b/projects/core/src/lib/utils/initial-calibration-plugin.ts
@@ -1,4 +1,5 @@
 import {MaskitoOptions, MaskitoPlugin} from '../types';
+import {maskitoSetElementValue} from './dom/set-element-value';
 import {maskitoTransform} from './transform';
 
 export function maskitoInitialCalibrationPlugin(
@@ -8,8 +9,10 @@ export function maskitoInitialCalibrationPlugin(
         const from = element.selectionStart || 0;
         const to = element.selectionEnd || 0;
 
-        element.value = maskitoTransform(element.value, customOptions || options);
-        element.dispatchEvent(new Event('input'));
+        maskitoSetElementValue(
+            element,
+            maskitoTransform(element.value, customOptions || options),
+        );
         element.setSelectionRange?.(from, to);
     };
 }

--- a/projects/kit/src/lib/masks/number/plugins/leading-zeroes-validation.plugin.ts
+++ b/projects/kit/src/lib/masks/number/plugins/leading-zeroes-validation.plugin.ts
@@ -1,4 +1,4 @@
-import {MaskitoPlugin, maskitoSetElementValue} from '@maskito/core';
+import {MaskitoPlugin, maskitoUpdateElement} from '@maskito/core';
 
 import {maskitoEventHandler} from '../../../plugins';
 import {createLeadingZeroesValidationPostprocessor} from '../processors';
@@ -31,7 +31,7 @@ export function createLeadingZeroesValidationPlugin(
             ).value;
 
             if (element.value !== newValue) {
-                maskitoSetElementValue(element, newValue);
+                maskitoUpdateElement(element, newValue);
             }
         },
         {capture: true},

--- a/projects/kit/src/lib/masks/number/plugins/leading-zeroes-validation.plugin.ts
+++ b/projects/kit/src/lib/masks/number/plugins/leading-zeroes-validation.plugin.ts
@@ -1,4 +1,4 @@
-import {MaskitoPlugin} from '@maskito/core';
+import {MaskitoPlugin, maskitoSetElementValue} from '@maskito/core';
 
 import {maskitoEventHandler} from '../../../plugins';
 import {createLeadingZeroesValidationPostprocessor} from '../processors';
@@ -31,8 +31,7 @@ export function createLeadingZeroesValidationPlugin(
             ).value;
 
             if (element.value !== newValue) {
-                element.value = newValue;
-                element.dispatchEvent(new Event('input'));
+                maskitoSetElementValue(element, newValue);
             }
         },
         {capture: true},

--- a/projects/kit/src/lib/masks/number/plugins/min-max.plugin.ts
+++ b/projects/kit/src/lib/masks/number/plugins/min-max.plugin.ts
@@ -1,4 +1,4 @@
-import {MaskitoPlugin, maskitoSetElementValue, maskitoTransform} from '@maskito/core';
+import {MaskitoPlugin, maskitoTransform, maskitoUpdateElement} from '@maskito/core';
 
 import {maskitoEventHandler} from '../../../plugins';
 import {clamp} from '../../../utils';
@@ -24,7 +24,7 @@ export function createMinMaxPlugin({
             const clampedNumber = clamp(parsedNumber, min, max);
 
             if (!Number.isNaN(parsedNumber) && parsedNumber !== clampedNumber) {
-                maskitoSetElementValue(
+                maskitoUpdateElement(
                     element,
                     maskitoTransform(stringifyNumberWithoutExp(clampedNumber), options),
                 );

--- a/projects/kit/src/lib/masks/number/plugins/min-max.plugin.ts
+++ b/projects/kit/src/lib/masks/number/plugins/min-max.plugin.ts
@@ -1,4 +1,4 @@
-import {MaskitoPlugin, maskitoTransform} from '@maskito/core';
+import {MaskitoPlugin, maskitoSetElementValue, maskitoTransform} from '@maskito/core';
 
 import {maskitoEventHandler} from '../../../plugins';
 import {clamp} from '../../../utils';
@@ -24,11 +24,10 @@ export function createMinMaxPlugin({
             const clampedNumber = clamp(parsedNumber, min, max);
 
             if (!Number.isNaN(parsedNumber) && parsedNumber !== clampedNumber) {
-                element.value = maskitoTransform(
-                    stringifyNumberWithoutExp(clampedNumber),
-                    options,
+                maskitoSetElementValue(
+                    element,
+                    maskitoTransform(stringifyNumberWithoutExp(clampedNumber), options),
                 );
-                element.dispatchEvent(new Event('input'));
             }
         },
         {capture: true},

--- a/projects/kit/src/lib/masks/number/plugins/not-empty-integer.plugin.ts
+++ b/projects/kit/src/lib/masks/number/plugins/not-empty-integer.plugin.ts
@@ -1,4 +1,4 @@
-import {MaskitoPlugin} from '@maskito/core';
+import {MaskitoPlugin, maskitoSetElementValue} from '@maskito/core';
 
 import {maskitoEventHandler} from '../../../plugins';
 import {escapeRegExp} from '../../../utils';
@@ -18,8 +18,7 @@ export function createNotEmptyIntegerPlugin(decimalSeparator: string): MaskitoPl
             );
 
             if (newValue !== element.value) {
-                element.value = newValue;
-                element.dispatchEvent(new Event('input'));
+                maskitoSetElementValue(element, newValue);
             }
         },
         {capture: true},

--- a/projects/kit/src/lib/masks/number/plugins/not-empty-integer.plugin.ts
+++ b/projects/kit/src/lib/masks/number/plugins/not-empty-integer.plugin.ts
@@ -1,4 +1,4 @@
-import {MaskitoPlugin, maskitoSetElementValue} from '@maskito/core';
+import {MaskitoPlugin, maskitoUpdateElement} from '@maskito/core';
 
 import {maskitoEventHandler} from '../../../plugins';
 import {escapeRegExp} from '../../../utils';
@@ -18,7 +18,7 @@ export function createNotEmptyIntegerPlugin(decimalSeparator: string): MaskitoPl
             );
 
             if (newValue !== element.value) {
-                maskitoSetElementValue(element, newValue);
+                maskitoUpdateElement(element, newValue);
             }
         },
         {capture: true},

--- a/projects/kit/src/lib/plugins/add-on-focus.ts
+++ b/projects/kit/src/lib/plugins/add-on-focus.ts
@@ -1,12 +1,11 @@
-import {MaskitoPlugin} from '@maskito/core';
+import {MaskitoPlugin, maskitoSetElementValue} from '@maskito/core';
 
 import {maskitoEventHandler} from './event-handler';
 
 export function maskitoAddOnFocusPlugin(value: string): MaskitoPlugin {
     return maskitoEventHandler('focus', element => {
         if (!element.value) {
-            element.value = value;
-            element.dispatchEvent(new Event('input'));
+            maskitoSetElementValue(element, value);
         }
     });
 }

--- a/projects/kit/src/lib/plugins/add-on-focus.ts
+++ b/projects/kit/src/lib/plugins/add-on-focus.ts
@@ -1,11 +1,11 @@
-import {MaskitoPlugin, maskitoSetElementValue} from '@maskito/core';
+import {MaskitoPlugin, maskitoUpdateElement} from '@maskito/core';
 
 import {maskitoEventHandler} from './event-handler';
 
 export function maskitoAddOnFocusPlugin(value: string): MaskitoPlugin {
     return maskitoEventHandler('focus', element => {
         if (!element.value) {
-            maskitoSetElementValue(element, value);
+            maskitoUpdateElement(element, value);
         }
     });
 }

--- a/projects/kit/src/lib/plugins/remove-on-blur.ts
+++ b/projects/kit/src/lib/plugins/remove-on-blur.ts
@@ -1,11 +1,11 @@
-import {MaskitoPlugin, maskitoSetElementValue} from '@maskito/core';
+import {MaskitoPlugin, maskitoUpdateElement} from '@maskito/core';
 
 import {maskitoEventHandler} from './event-handler';
 
 export function maskitoRemoveOnBlurPlugin(value: string): MaskitoPlugin {
     return maskitoEventHandler('blur', element => {
         if (element.value === value) {
-            maskitoSetElementValue(element, '');
+            maskitoUpdateElement(element, '');
         }
     });
 }

--- a/projects/kit/src/lib/plugins/remove-on-blur.ts
+++ b/projects/kit/src/lib/plugins/remove-on-blur.ts
@@ -1,12 +1,11 @@
-import {MaskitoPlugin} from '@maskito/core';
+import {MaskitoPlugin, maskitoSetElementValue} from '@maskito/core';
 
 import {maskitoEventHandler} from './event-handler';
 
 export function maskitoRemoveOnBlurPlugin(value: string): MaskitoPlugin {
     return maskitoEventHandler('blur', element => {
         if (element.value === value) {
-            element.value = '';
-            element.dispatchEvent(new Event('input'));
+            maskitoSetElementValue(element, '');
         }
     });
 }

--- a/projects/kit/src/lib/processors/with-placeholder.ts
+++ b/projects/kit/src/lib/processors/with-placeholder.ts
@@ -1,4 +1,4 @@
-import {MaskitoOptions, maskitoSetElementValue} from '@maskito/core';
+import {MaskitoOptions, maskitoUpdateElement} from '@maskito/core';
 
 import {maskitoCaretGuard, maskitoEventHandler} from '../plugins';
 
@@ -26,7 +26,7 @@ export function maskitoWithPlaceholder(
             'focus',
             element => {
                 focused = true;
-                maskitoSetElementValue(
+                maskitoUpdateElement(
                     element,
                     element.value + placeholder.slice(element.value.length),
                 );
@@ -38,7 +38,7 @@ export function maskitoWithPlaceholder(
             'blur',
             element => {
                 focused = false;
-                maskitoSetElementValue(element, removePlaceholder(element.value));
+                maskitoUpdateElement(element, removePlaceholder(element.value));
             },
             {capture: true},
         );

--- a/projects/kit/src/lib/processors/with-placeholder.ts
+++ b/projects/kit/src/lib/processors/with-placeholder.ts
@@ -1,4 +1,4 @@
-import {MaskitoOptions} from '@maskito/core';
+import {MaskitoOptions, maskitoSetElementValue} from '@maskito/core';
 
 import {maskitoCaretGuard, maskitoEventHandler} from '../plugins';
 
@@ -26,8 +26,10 @@ export function maskitoWithPlaceholder(
             'focus',
             element => {
                 focused = true;
-                element.value += placeholder.slice(element.value.length);
-                element.dispatchEvent(new Event('input'));
+                maskitoSetElementValue(
+                    element,
+                    element.value + placeholder.slice(element.value.length),
+                );
             },
             {capture: true},
         );
@@ -36,8 +38,7 @@ export function maskitoWithPlaceholder(
             'blur',
             element => {
                 focused = false;
-                element.value = removePlaceholder(element.value);
-                element.dispatchEvent(new Event('input'));
+                maskitoSetElementValue(element, removePlaceholder(element.value));
             },
             {capture: true},
         );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Closes #804

## What is the new behaviour?

Every dispatchEvent of input event now passes the bubbling stage, and it works with React