### PR TITLE
fix(kit): `maskitoParseNumber` cannot parse prefix/postfix with points

### DIFF
--- a/projects/kit/src/lib/masks/number/utils/parse-number.ts
+++ b/projects/kit/src/lib/masks/number/utils/parse-number.ts
@@ -8,8 +8,13 @@ export function maskitoParseNumber(
     const hasNegativeSign = !!maskedNumber.match(
         new RegExp(`^\\D*[${CHAR_MINUS}\\${CHAR_HYPHEN}${CHAR_EN_DASH}${CHAR_EM_DASH}]`),
     );
+    const escapedDecimalSeparator = escapeRegExp(decimalSeparator);
+
     const unmaskedNumber = maskedNumber
-        .replace(new RegExp(`[^\\d${escapeRegExp(decimalSeparator)}]`, 'g'), '')
+        // drop all decimal separators not followed by a digit
+        .replace(new RegExp(`${escapedDecimalSeparator}(?!\\d)`, 'g'), '')
+        // drop all non-digit characters except decimal separator
+        .replace(new RegExp(`[^\\d${escapedDecimalSeparator}]`, 'g'), '')
         .replace(decimalSeparator, '.');
 
     return unmaskedNumber

--- a/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
@@ -91,6 +91,38 @@ describe('maskitoParseNumber', () => {
             expect(maskitoParseNumber('>-42')).toBe(-42);
             expect(maskitoParseNumber('> -42')).toBe(-42);
         });
+
+        describe('prefix/postfix includes point and space', () => {
+            it('parses INTEGER number with postfix " lbs."', () => {
+                expect(maskitoParseNumber('42 lbs.')).toBe(42);
+                expect(maskitoParseNumber('1 000 lbs.')).toBe(1000);
+                expect(maskitoParseNumber('1 000 lbs.')).toBe(1000);
+            });
+
+            it('parses DECIMAL number with postfix " lbs."', () => {
+                expect(maskitoParseNumber('0.42 lbs.')).toBe(0.42);
+                expect(maskitoParseNumber('.42 lbs.')).toBe(0.42);
+                expect(maskitoParseNumber('1 000.42 lbs.')).toBe(1000.42);
+                expect(maskitoParseNumber('1 000. lbs.')).toBe(1000);
+            });
+
+            it('parses INTEGER number with prefix "lbs. "', () => {
+                expect(maskitoParseNumber('lbs. 42')).toBe(42);
+                expect(maskitoParseNumber('lbs. 1 000')).toBe(1000);
+                expect(maskitoParseNumber('lbs. 1 000')).toBe(1000);
+            });
+
+            it('parses DECIMAL number with prefix "lbs. "', () => {
+                expect(maskitoParseNumber('lbs. 0.42')).toBe(0.42);
+                expect(maskitoParseNumber('lbs. .42')).toBe(0.42);
+                expect(maskitoParseNumber('lbs. 1 000.42')).toBe(1000.42);
+                expect(maskitoParseNumber('lbs. 1 000.42')).toBe(1000.42);
+
+                const zeroWidthSpace = '\u200B';
+
+                expect(maskitoParseNumber(`lbs.${zeroWidthSpace}1 000.42`)).toBe(1000.42);
+            });
+        });
     });
 
     describe('NaN', () => {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
```ts
maskitoParseNumber('0.42 lbs.') // NaN
maskitoParseNumber('1 000.42 lbs.') // NaN
maskitoParseNumber('lbs. 42') // 0.42
```

## What is the new behaviour?
```ts
maskitoParseNumber('0.42 lbs.') // 0.42
maskitoParseNumber('1 000.42 lbs.') // 1 000.42
maskitoParseNumber('lbs. 42') // 42
```

**Partially** solves https://github.com/taiga-family/maskito/issues/703
Relates to https://github.com/taiga-family/maskito/pull/816
