### PR TITLE
chore(demo): workaround for `vue@3.4.0` regression

### DIFF
--- a/projects/demo/webpack.config.ts
+++ b/projects/demo/webpack.config.ts
@@ -1,4 +1,4 @@
-import {Configuration} from 'webpack';
+import {Configuration, DefinePlugin} from 'webpack';
 import {merge} from 'webpack-merge';
 
 /**
@@ -42,6 +42,11 @@ const config: Configuration = {
             vue$: 'vue/dist/vue.esm-bundler.js',
         },
     },
+    plugins: [
+        new DefinePlugin({
+            __VUE_PROD_DEVTOOLS__: 'false', // vue 3.4.0 regression (https://github.com/vuejs/core/issues/10039#issuecomment-1883015495)
+        }),
+    ],
     output: {
         hashFunction: 'xxhash64',
     },


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- [X] Documentation content changes

## What is the current behaviour?
Open https://maskito.dev/frameworks/vue

<img width="1552" alt="Screenshot 2024-01-11 at 16 53 45" src="https://github.com/taiga-family/maskito/assets/35179038/8888c91b-1910-44a6-93ed-0548ed3bdffc">

Relates to https://github.com/vuejs/core/issues/10039