### PR TITLE
fix(kit): `Number` should use zero-width space if prefix ends with decimal separator

### DIFF
--- a/projects/demo-integrations/src/tests/kit/number/number-prefix-postfix.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/number/number-prefix-postfix.cy.ts
@@ -332,4 +332,55 @@ describe('Number | Prefix & Postfix', () => {
             });
         });
     });
+
+    describe('prefix ends with the same character as postfix starts', () => {
+        const prefix = 'lbs.​'; // padded with zero-width space
+
+        beforeEach(() => {
+            openNumberPage('prefix=lbs.&precision=2');
+
+            cy.get('@input')
+                .focus()
+                .should('have.value', prefix)
+                .should('have.prop', 'selectionStart', prefix.length)
+                .should('have.prop', 'selectionEnd', prefix.length);
+        });
+
+        it('lbs.| => Type Backspace (attempt to erase zero-width space) => lbs.|', () => {
+            cy.get('@input')
+                .type('{backspace}')
+                .should('have.value', prefix)
+                .should('have.prop', 'selectionStart', prefix.length)
+                .should('have.prop', 'selectionEnd', prefix.length);
+        });
+
+        it('lbs.| => Type 42 => lbs.42|', () => {
+            cy.get('@input')
+                .type('42')
+                .should('have.value', `${prefix}42`)
+                .should('have.prop', 'selectionStart', `${prefix}42`.length)
+                .should('have.prop', 'selectionEnd', `${prefix}42`.length);
+        });
+
+        it('lbs.| => Type .42 => lbs.0.42|', () => {
+            cy.get('@input')
+                .type('.42')
+                .should('have.value', `${prefix}0.42`)
+                .should('have.prop', 'selectionStart', `${prefix}0.42`.length)
+                .should('have.prop', 'selectionEnd', `${prefix}0.42`.length);
+        });
+
+        it('lbs.0|.42 => Backspace + Blur => lbs.0.42', () => {
+            cy.get('@input')
+                .type('0.42')
+                .type('{leftArrow}'.repeat('.42'.length))
+                .type('{backspace}')
+                .should('have.value', `${prefix}.42`)
+                .should('have.prop', 'selectionStart', prefix.length)
+                .should('have.prop', 'selectionEnd', prefix.length)
+                .blur()
+                .wait(100) // to be sure that value is not changed even in case of some async validation
+                .should('have.value', `${prefix}0.42`);
+        });
+    });
 });

--- a/projects/kit/src/lib/constants/unicode-characters.ts
+++ b/projects/kit/src/lib/constants/unicode-characters.ts
@@ -4,6 +4,11 @@
 export const CHAR_NO_BREAK_SPACE = '\u00A0';
 
 /**
+ * {@link https://symbl.cc/en/200B/ Zero width space}.
+ */
+export const CHAR_ZERO_WIDTH_SPACE = '\u200B';
+
+/**
  * {@link https://unicode-table.com/en/2013/ EN dash}
  * is used to indicate a range of numbers or a span of time.
  * @example 2006–2022

--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -7,6 +7,7 @@ import {
     CHAR_JP_HYPHEN,
     CHAR_MINUS,
     CHAR_NO_BREAK_SPACE,
+    CHAR_ZERO_WIDTH_SPACE,
 } from '../../constants';
 import {
     maskitoPostfixPostprocessorGenerator,
@@ -18,6 +19,7 @@ import {
     createNotEmptyIntegerPlugin,
 } from './plugins';
 import {
+    createAffixesFilterPreprocessor,
     createDecimalZeroPaddingPostprocessor,
     createFullWidthToHalfWidthPreprocessor,
     createInitializationOnlyPreprocessor,
@@ -29,7 +31,6 @@ import {
     createThousandSeparatorPostprocessor,
     createZeroPrecisionPreprocessor,
 } from './processors';
-import {createAffixesFilterPreprocessor} from './processors/affixes-filter-preprocessor';
 import {generateMaskExpression, validateDecimalPseudoSeparators} from './utils';
 
 export function maskitoNumberOptionsGenerator({
@@ -40,7 +41,7 @@ export function maskitoNumberOptionsGenerator({
     decimalSeparator = '.',
     decimalPseudoSeparators,
     decimalZeroPadding = false,
-    prefix = '',
+    prefix: unsafePrefix = '',
     postfix = '',
 }: {
     min?: number;
@@ -64,6 +65,10 @@ export function maskitoNumberOptionsGenerator({
         thousandSeparator,
         decimalPseudoSeparators,
     });
+    const prefix =
+        unsafePrefix.endsWith(decimalSeparator) && precision > 0
+            ? `${unsafePrefix}${CHAR_ZERO_WIDTH_SPACE}`
+            : unsafePrefix;
 
     return {
         ...MASKITO_DEFAULT_OPTIONS,
@@ -97,7 +102,12 @@ export function maskitoNumberOptionsGenerator({
                 prefix,
                 postfix,
             }),
-            createNotEmptyIntegerPartPreprocessor({decimalSeparator, precision}),
+            createNotEmptyIntegerPartPreprocessor({
+                decimalSeparator,
+                precision,
+                prefix,
+                postfix,
+            }),
             createNonRemovableCharsDeletionPreprocessor({
                 decimalSeparator,
                 decimalZeroPadding,

--- a/projects/kit/src/lib/masks/number/processors/index.ts
+++ b/projects/kit/src/lib/masks/number/processors/index.ts
@@ -1,3 +1,4 @@
+export * from './affixes-filter-preprocessor';
 export * from './decimal-zero-padding-postprocessor';
 export * from './fullwidth-to-halfwidth-preprocessor';
 export * from './initialization-only-preprocessor';

--- a/projects/kit/src/lib/masks/number/processors/not-empty-integer-part-preprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/not-empty-integer-part-preprocessor.ts
@@ -1,6 +1,6 @@
 import {MaskitoPreprocessor} from '@maskito/core';
 
-import {escapeRegExp} from '../../../utils';
+import {escapeRegExp, extractAffixes} from '../../../utils';
 
 /**
  * It pads integer part with zero if user types decimal separator (for empty input).
@@ -9,9 +9,13 @@ import {escapeRegExp} from '../../../utils';
 export function createNotEmptyIntegerPartPreprocessor({
     decimalSeparator,
     precision,
+    prefix,
+    postfix,
 }: {
     decimalSeparator: string;
     precision: number;
+    prefix: string;
+    postfix: string;
 }): MaskitoPreprocessor {
     const startWithDecimalSepRegExp = new RegExp(
         `^\\D*${escapeRegExp(decimalSeparator)}`,
@@ -19,17 +23,21 @@ export function createNotEmptyIntegerPartPreprocessor({
 
     return ({elementState, data}) => {
         const {value, selection} = elementState;
+        const {cleanValue} = extractAffixes(value, {
+            prefix,
+            postfix,
+        });
         const [from] = selection;
 
         if (
             precision <= 0 ||
-            value.includes(decimalSeparator) ||
+            cleanValue.includes(decimalSeparator) ||
             !data.match(startWithDecimalSepRegExp)
         ) {
             return {elementState, data};
         }
 
-        const digitsBeforeCursor = value.slice(0, from).match(/\d+/);
+        const digitsBeforeCursor = cleanValue.slice(0, from).match(/\d+/);
 
         return {
             elementState,

--- a/projects/kit/src/lib/masks/number/processors/tests/not-empty-integer-part-preprocessor.spec.ts
+++ b/projects/kit/src/lib/masks/number/processors/tests/not-empty-integer-part-preprocessor.spec.ts
@@ -10,6 +10,8 @@ describe('createNotEmptyIntegerPartPreprocessor', () => {
         const preprocessor = createNotEmptyIntegerPartPreprocessor({
             decimalSeparator: ',',
             precision: 2,
+            prefix: '',
+            postfix: '',
         });
 
         it('should pad integer part with zero if user inserts "a,"', () => {

--- a/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
+++ b/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
@@ -289,7 +289,7 @@ describe('Number (maskitoTransform)', () => {
                 expect(maskitoParseNumber(expected)).toBe(1000);
             });
 
-            it('1 000. => lbs.1 000', () => {
+            it('1 000. => lbs.1 000.', () => {
                 const expected = `lbs.${CHAR_ZERO_WIDTH_SPACE}1${CHAR_NO_BREAK_SPACE}000.`;
 
                 expect(maskitoTransform('1 000.', options)).toBe(expected);

--- a/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
+++ b/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
@@ -1,5 +1,7 @@
 import {MASKITO_DEFAULT_OPTIONS, MaskitoOptions, maskitoTransform} from '@maskito/core';
+import {maskitoParseNumber} from '@maskito/kit';
 
+import {CHAR_NO_BREAK_SPACE, CHAR_ZERO_WIDTH_SPACE} from '../../../constants';
 import {maskitoNumberOptionsGenerator} from '../number-mask';
 
 describe('Number (maskitoTransform)', () => {
@@ -236,6 +238,62 @@ describe('Number (maskitoTransform)', () => {
 
             it('lbs. 1 000 => lbs. 1 000', () => {
                 expect(maskitoTransform('lbs. 1 000', options)).toBe('lbs. 1 000');
+            });
+        });
+
+        describe('prefix ends with same character as decimal separator equals (zero-width space workaround)', () => {
+            beforeEach(() => {
+                options = maskitoNumberOptionsGenerator({
+                    prefix: 'lbs.',
+                    decimalSeparator: '.',
+                    precision: 2,
+                });
+            });
+
+            it('Empty textfield => empty textfield', () => {
+                expect(maskitoTransform('', options)).toBe('');
+            });
+
+            it('Only prefix => prefix with zero-width space', () => {
+                expect(maskitoTransform('lbs.', options)).toBe(
+                    `lbs.${CHAR_ZERO_WIDTH_SPACE}`,
+                );
+            });
+
+            it('5 => lbs.5', () => {
+                expect(maskitoTransform('5', options)).toBe(
+                    `lbs.${CHAR_ZERO_WIDTH_SPACE}5`,
+                );
+            });
+
+            it('0.42 => lbs.0.42', () => {
+                const expected = `lbs.${CHAR_ZERO_WIDTH_SPACE}0.42`;
+
+                expect(maskitoTransform('0.42', options)).toBe(expected);
+                expect(maskitoParseNumber(expected)).toBe(0.42);
+            });
+
+            it('42 => lbs.42', () => {
+                const expected = `lbs.${CHAR_ZERO_WIDTH_SPACE}42`;
+
+                expect(maskitoTransform('42', options)).toBe(expected);
+                expect(maskitoParseNumber(expected)).toBe(42);
+            });
+
+            it('1 000 => lbs.1 000', () => {
+                const expected = `lbs.${CHAR_ZERO_WIDTH_SPACE}1${CHAR_NO_BREAK_SPACE}000`;
+
+                expect(maskitoTransform(`1${CHAR_NO_BREAK_SPACE}000`, options)).toBe(
+                    expected,
+                );
+                expect(maskitoParseNumber(expected)).toBe(1000);
+            });
+
+            it('1 000. => lbs.1 000', () => {
+                const expected = `lbs.${CHAR_ZERO_WIDTH_SPACE}1${CHAR_NO_BREAK_SPACE}000.`;
+
+                expect(maskitoTransform('1 000.', options)).toBe(expected);
+                expect(maskitoParseNumber(expected)).toBe(1000);
             });
         });
     });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

Relates to https://github.com/taiga-family/maskito/pull/816#discussion_r1446023930
Closes https://github.com/taiga-family/maskito/issues/703
