### PR TITLE
fix(kit): `Number` rejects the first time input of full width digits

### DIFF
--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -81,6 +81,7 @@ export function maskitoNumberOptionsGenerator({
             isNegativeAllowed: min < 0,
         }),
         preprocessors: [
+            createFullWidthToHalfWidthPreprocessor(),
             createInitializationOnlyPreprocessor({
                 decimalSeparator,
                 decimalPseudoSeparators: validatedDecimalPseudoSeparators,
@@ -89,7 +90,6 @@ export function maskitoNumberOptionsGenerator({
                 postfix,
             }),
             createAffixesFilterPreprocessor({prefix, postfix}),
-            createFullWidthToHalfWidthPreprocessor(),
             createPseudoCharactersPreprocessor({
                 validCharacter: CHAR_MINUS,
                 pseudoCharacters: pseudoMinuses,

--- a/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
+++ b/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
@@ -297,4 +297,25 @@ describe('Number (maskitoTransform)', () => {
             });
         });
     });
+
+    describe('should transform full width number to half width', () => {
+        describe('at any time', () => {
+            it('at the 1st time (after initialization)', () => {
+                const options = maskitoNumberOptionsGenerator({
+                    thousandSeparator: '_',
+                });
+
+                expect(maskitoTransform('１２３４５', options)).toBe('12_345');
+            });
+
+            it('at the 2nd time (after initialization)', () => {
+                const options = maskitoNumberOptionsGenerator({
+                    thousandSeparator: '_',
+                });
+
+                maskitoTransform('１２３４５', options);
+                expect(maskitoTransform('１２３４５', options)).toBe('12_345');
+            });
+        });
+    });
 });


### PR DESCRIPTION
1. Open https://maskito.dev/kit/number#high-precision
2. Enter full width digit (e.g. `１`)


https://github.com/taiga-family/maskito/assets/35179038/e29fe2e1-3cea-41e0-b5b5-11f6ea4758c1



