### PR TITLE
fix(react): `@maskito/react` library should not include `core-js` imports

### DIFF
--- a/projects/react/.babelrc
+++ b/projects/react/.babelrc
@@ -3,8 +3,7 @@
         [
             "@nx/react/babel",
             {
-                "runtime": "automatic",
-                "useBuiltIns": "usage"
+                "runtime": "automatic"
             }
         ]
     ],

--- a/projects/react/project.json
+++ b/projects/react/project.json
@@ -15,6 +15,7 @@
                 "entryFile": "projects/react/src/index.ts",
                 "external": "all",
                 "rollupConfig": "@nx/react/plugins/bundle-rollup",
+                "compiler": "babel",
                 "assets": [
                     {
                         "glob": "projects/react/README.md",


### PR DESCRIPTION
## Before
Run `nx build react`

<img width="1757" alt="before" src="https://github.com/taiga-family/maskito/assets/35179038/d91bc69e-a873-4d69-ad2c-9934cc1f9c7d">

## After
<img width="1757" alt="after" src="https://github.com/taiga-family/maskito/assets/35179038/f0339893-50b7-483d-a392-c0594680ae4a">

<br />

Learn more: https://babeljs.io/docs/babel-preset-env#usebuiltins

Closes #956
