### PR TITLE
fix(react): `@maskito/react` includes again missing `cjs` module format

### DIFF
--- a/projects/react/project.json
+++ b/projects/react/project.json
@@ -16,6 +16,7 @@
                 "external": "all",
                 "rollupConfig": "@nx/react/plugins/bundle-rollup",
                 "compiler": "babel",
+                "format": ["esm", "cjs"],
                 "assets": [
                     {
                         "glob": "projects/react/README.md",


### PR DESCRIPTION
# Bug description

`@maskito/react@1.9.0` has `umd`-format (for Node.js; for example `Jest`-tests):
<img width="870" alt="1 9 0" src="https://github.com/taiga-family/maskito/assets/35179038/e208ad3e-4928-47a4-ae2c-aacb427770f6">

___

`@maskito/react@2.0.0` does **not** have `umd`-format
<img width="870" alt="2 0 0" src="https://github.com/taiga-family/maskito/assets/35179038/8355c6fc-8696-4587-a3b1-ed8b70f2fa02">

___

It is `2.0.0`'s regression bug. 
It is connected to `Nx` [14.1.8](https://github.com/nrwl/nx/releases/tag/14.1.8)-release.
Default value of `format` for `rollup` is set ESM only.
Learn more: https://github.com/nrwl/nx/pull/10349


## New behaviour
`@maskito/react` includes again both ESM and CJS (previous UMD users can use CJS).
Closes #983
