### PR TITLE
fix(kit): `maskitoParseNumber` should interpret japanese prolonged sound mark as pseudo minus

### DIFF
--- a/projects/kit/src/lib/masks/number/utils/parse-number.ts
+++ b/projects/kit/src/lib/masks/number/utils/parse-number.ts
@@ -1,9 +1,17 @@
-import {CHAR_EM_DASH, CHAR_EN_DASH, CHAR_HYPHEN, CHAR_MINUS} from '../../../constants';
+import {
+    CHAR_EM_DASH,
+    CHAR_EN_DASH,
+    CHAR_HYPHEN,
+    CHAR_JP_HYPHEN,
+    CHAR_MINUS,
+} from '../../../constants';
 import {escapeRegExp} from '../../../utils';
 
 export function maskitoParseNumber(maskedNumber: string, decimalSeparator = '.'): number {
     const hasNegativeSign = !!maskedNumber.match(
-        new RegExp(`^\\D*[${CHAR_MINUS}\\${CHAR_HYPHEN}${CHAR_EN_DASH}${CHAR_EM_DASH}]`),
+        new RegExp(
+            `^\\D*[${CHAR_MINUS}\\${CHAR_HYPHEN}${CHAR_EN_DASH}${CHAR_EM_DASH}${CHAR_JP_HYPHEN}]`,
+        ),
     );
     const escapedDecimalSeparator = escapeRegExp(decimalSeparator);
 

--- a/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
@@ -1,4 +1,10 @@
-import {CHAR_EM_DASH, CHAR_EN_DASH, CHAR_HYPHEN, CHAR_MINUS} from '../../../../constants';
+import {
+    CHAR_EM_DASH,
+    CHAR_EN_DASH,
+    CHAR_HYPHEN,
+    CHAR_JP_HYPHEN,
+    CHAR_MINUS,
+} from '../../../../constants';
 import {maskitoParseNumber} from '../parse-number';
 
 describe('maskitoParseNumber', () => {
@@ -62,6 +68,10 @@ describe('maskitoParseNumber', () => {
 
             it('can be em-dash', () => {
                 expect(maskitoParseNumber(`${CHAR_EM_DASH}42`)).toBe(-42);
+            });
+
+            it('can be katakana-hiragana prolonged sound mark', () => {
+                expect(maskitoParseNumber(`${CHAR_JP_HYPHEN}42`)).toBe(-42);
             });
         });
 


### PR DESCRIPTION
Relates https://github.com/taiga-family/maskito/pull/864