### PR TITLE
fix: totally disable `Maskito` if nullable options are passed inside `@maskito/{angular,react,vue}`

### DIFF
--- a/projects/demo-integrations/src/tests/component-testing/angular/disable-mask-on-null.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/angular/disable-mask-on-null.cy.ts
@@ -1,0 +1,42 @@
+import {MaskitoOptions} from '@maskito/core';
+
+import {TestInput} from '../utils';
+
+describe('@maskito/angular | Disable mask if null is passed as options', () => {
+    describe('type="email" is not compatible with Maskito (it does not have `setSelectionRange`)', () => {
+        it('should throw error if non-nullable options are passed', done => {
+            const maskitoOptions: MaskitoOptions = {
+                mask: [/[a-z]/, /[a-z]/, '@', /[a-z]/],
+            };
+
+            cy.mount(TestInput, {
+                componentProperties: {
+                    type: 'email',
+                    maskitoOptions,
+                },
+            });
+
+            cy.on('uncaught:exception', ({message}) => {
+                expect(message).to.include(
+                    "Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('email') does not support selection",
+                );
+
+                // ensure that an uncaught exception was thrown
+                done();
+            });
+
+            cy.get('input').type('a12bc');
+        });
+
+        it('should not throw any error is options are equal to `null`', () => {
+            cy.mount(TestInput, {
+                componentProperties: {
+                    type: 'email',
+                    maskitoOptions: null,
+                },
+            });
+
+            cy.get('input').type('a12bc').should('have.value', 'a12bc');
+        });
+    });
+});

--- a/projects/demo-integrations/src/tests/component-testing/utils.ts
+++ b/projects/demo-integrations/src/tests/component-testing/utils.ts
@@ -12,6 +12,7 @@ import {
     template: `
         <input
             [attr.maxlength]="maxLength"
+            [attr.type]="type"
             [attr.value]="initialValue"
             [maskito]="maskitoOptions"
             [maskitoElement]="maskitoElementPredicate"
@@ -35,4 +36,7 @@ export class TestInput {
 
     @Input()
     public maxLength = Infinity;
+
+    @Input()
+    public type: HTMLInputElement['type'] = 'text';
 }

--- a/projects/react/src/lib/useMaskito.ts
+++ b/projects/react/src/lib/useMaskito.ts
@@ -1,7 +1,6 @@
 import {
     Maskito,
     MASKITO_DEFAULT_ELEMENT_PREDICATE,
-    MASKITO_DEFAULT_OPTIONS,
     MaskitoElementPredicate,
     MaskitoOptions,
 } from '@maskito/core';
@@ -28,10 +27,10 @@ function isThenable<T = unknown>(x: PromiseLike<T> | T): x is PromiseLike<T> {
  * useMaskito({ options: { mask: /^.*$/ }, elementPredicate: () => e.querySelector('input') })
  */
 export const useMaskito = ({
-    options = MASKITO_DEFAULT_OPTIONS,
+    options = null,
     elementPredicate = MASKITO_DEFAULT_ELEMENT_PREDICATE,
 }: {
-    options?: MaskitoOptions;
+    options?: MaskitoOptions | null;
     elementPredicate?: MaskitoElementPredicate;
 } = {}): RefCallback<HTMLElement> => {
     const [hostElement, setHostElement] = useState<HTMLElement | null>(null);
@@ -70,7 +69,7 @@ export const useMaskito = ({
     }, [hostElement, elementPredicate, latestPredicateRef]);
 
     useIsomorphicLayoutEffect(() => {
-        if (!element) {
+        if (!element || !options) {
             return;
         }
 

--- a/projects/vue/src/lib/maskito.ts
+++ b/projects/vue/src/lib/maskito.ts
@@ -11,11 +11,13 @@ const predicates = new Map<HTMLElement, MaskitoElementPredicate>();
 
 async function update(
     element: HTMLElement,
-    options: MaskitoOptions & {
-        elementPredicate?: MaskitoElementPredicate;
-    },
+    options:
+        | (MaskitoOptions & {
+              elementPredicate?: MaskitoElementPredicate;
+          })
+        | null,
 ): Promise<void> {
-    const predicate = options.elementPredicate ?? MASKITO_DEFAULT_ELEMENT_PREDICATE;
+    const predicate = options?.elementPredicate ?? MASKITO_DEFAULT_ELEMENT_PREDICATE;
 
     predicates.set(element, predicate);
 
@@ -26,14 +28,18 @@ async function update(
     }
 
     teardown.get(element)?.destroy();
-    teardown.set(element, new Maskito(predicateResult, options));
+
+    if (options) {
+        teardown.set(element, new Maskito(predicateResult, options));
+    }
 }
 
 export const maskito: ObjectDirective<
     HTMLElement,
-    MaskitoOptions & {
-        elementPredicate?: MaskitoElementPredicate;
-    }
+    | (MaskitoOptions & {
+          elementPredicate?: MaskitoElementPredicate;
+      })
+    | null
 > = {
     unmounted: element => {
         teardown.get(element)?.destroy();


### PR DESCRIPTION
Closes #1101
