### PR TITLE
chore: fix IDE error when import `is not under rootDir`

### DIFF
--- a/projects/core/tsconfig.lib.json
+++ b/projects/core/tsconfig.lib.json
@@ -1,6 +1,3 @@
 {
-    "extends": "../../tsconfig.build.json",
-    "compilerOptions": {
-        "rootDir": "."
-    }
+    "extends": "../../tsconfig.build.json"
 }

--- a/projects/kit/tsconfig.lib.json
+++ b/projects/kit/tsconfig.lib.json
@@ -1,6 +1,3 @@
 {
-    "extends": "../../tsconfig.build.json",
-    "compilerOptions": {
-        "rootDir": "."
-    }
+    "extends": "../../tsconfig.build.json"
 }

--- a/projects/phone/tsconfig.lib.json
+++ b/projects/phone/tsconfig.lib.json
@@ -1,6 +1,3 @@
 {
-    "extends": "../../tsconfig.build.json",
-    "compilerOptions": {
-        "rootDir": "."
-    }
+    "extends": "../../tsconfig.build.json"
 }

--- a/projects/vue/tsconfig.lib.json
+++ b/projects/vue/tsconfig.lib.json
@@ -1,6 +1,3 @@
 {
-    "extends": "../../tsconfig.build.json",
-    "compilerOptions": {
-        "rootDir": "."
-    }
+    "extends": "../../tsconfig.build.json"
 }


### PR DESCRIPTION
# Previous behavior
<img width="1486" alt="before" src="https://github.com/taiga-family/maskito/assets/35179038/af038ee3-c289-40fd-89b6-37d4e67a89b8">

# New behavior
<img width="1486" alt="after" src="https://github.com/taiga-family/maskito/assets/35179038/d810a438-7bf1-4c18-ae43-a0a250faccbc">

