### PR TITLE
fix(kit): `Date` formatting errors for `mm/yyyy`, `yyyy/mm`, `mm/yy` modes

### DIFF
--- a/projects/demo-integrations/src/tests/kit/date/date-mode.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date/date-mode.cy.ts
@@ -82,7 +82,7 @@ describe('Date', () => {
                     .should('have.prop', 'selectionEnd', '03.22'.length);
             });
 
-            it('"mm/yy" => 05.04', () => {
+            it('"mm/yy" => 12.04', () => {
                 cy.get('@input')
                     .type('1.2.')
                     .should('have.value', '12.')
@@ -170,7 +170,7 @@ describe('Date', () => {
                     .should('have.prop', 'selectionEnd', '1999.11'.length);
             });
 
-            it('"yyyy/mm" => 20004.05', () => {
+            it('"yyyy/mm" => 2004.05', () => {
                 cy.get('@input')
                     .type('20.0.4')
                     .should('have.value', '2004')

--- a/projects/demo-integrations/src/tests/kit/date/date-mode.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date/date-mode.cy.ts
@@ -58,7 +58,7 @@ describe('Date', () => {
                     .as('input');
             });
 
-            it(' "mm/yy" => 03.20', () => {
+            it('"mm/yy" => 03.20', () => {
                 cy.get('@input')
                     .type('3')
                     .should('have.value', '03')
@@ -70,7 +70,7 @@ describe('Date', () => {
                     .should('have.prop', 'selectionEnd', '03.20'.length);
             });
 
-            it(' "mm/yy" => 03.22', () => {
+            it('"mm/yy" => 03.22', () => {
                 cy.get('@input')
                     .type('0')
                     .should('have.value', '0')
@@ -80,6 +80,14 @@ describe('Date', () => {
                     .should('have.value', '03.22')
                     .should('have.prop', 'selectionStart', '03.22'.length)
                     .should('have.prop', 'selectionEnd', '03.22'.length);
+            });
+
+            it('"mm/yy" => 05.04', () => {
+                cy.get('@input')
+                    .type('1.2.')
+                    .should('have.value', '12.')
+                    .type('04')
+                    .should('have.value', '12.04');
             });
         });
 
@@ -116,6 +124,16 @@ describe('Date', () => {
                     .should('have.prop', 'selectionStart', '11.1999'.length)
                     .should('have.prop', 'selectionEnd', '11.1999'.length);
             });
+
+            it('"mm/yyyy" => 05.2004', () => {
+                cy.get('@input')
+                    .type('0.')
+                    .should('have.value', '0')
+                    .type('5')
+                    .should('have.value', '05')
+                    .type('.2004')
+                    .should('have.value', '05.2004');
+            });
         });
 
         describe('yyyy/mm', () => {
@@ -150,6 +168,16 @@ describe('Date', () => {
                     .should('have.value', '1999.11')
                     .should('have.prop', 'selectionStart', '1999.11'.length)
                     .should('have.prop', 'selectionEnd', '1999.11'.length);
+            });
+
+            it('"yyyy/mm" => 20004.05', () => {
+                cy.get('@input')
+                    .type('20.0.4')
+                    .should('have.value', '2004')
+                    .type('.')
+                    .should('have.value', '2004.')
+                    .type('05')
+                    .should('have.value', '2004.05');
             });
         });
 

--- a/projects/kit/src/lib/processors/normalize-date-preprocessor.ts
+++ b/projects/kit/src/lib/processors/normalize-date-preprocessor.ts
@@ -18,7 +18,6 @@ export function normalizeDatePreprocessor({
             ? new RegExp(`${rangeSeparator}|-`)
             : dateTimeSeparator;
         const possibleDates = data.split(separator);
-
         const dates = data.includes(dateTimeSeparator)
             ? [possibleDates[0]]
             : possibleDates;
@@ -26,7 +25,10 @@ export function normalizeDatePreprocessor({
         if (
             dates.every(
                 date =>
-                    date.trim().split(/\D/).length ===
+                    date
+                        .trim()
+                        .split(/\D/)
+                        .filter(str => str).length ===
                     dateModeTemplate.split(dateSegmentsSeparator).length,
             )
         ) {
@@ -55,7 +57,7 @@ function normalizeDateString(
     template: string,
     separator: string,
 ): string {
-    const dateSegments = dateString.split(/\D/);
+    const dateSegments = dateString.split(/\D/).filter(str => str);
     const templateSegments = template.split(separator);
     const normalizedSegments = dateSegments.map((segment, index) =>
         index === templateSegments.length - 1

--- a/projects/kit/src/lib/processors/normalize-date-preprocessor.ts
+++ b/projects/kit/src/lib/processors/normalize-date-preprocessor.ts
@@ -25,10 +25,7 @@ export function normalizeDatePreprocessor({
         if (
             dates.every(
                 date =>
-                    date
-                        .trim()
-                        .split(/\D/)
-                        .filter(str => str).length ===
+                    date.trim().split(/\D/).filter(Boolean).length ===
                     dateModeTemplate.split(dateSegmentsSeparator).length,
             )
         ) {
@@ -57,7 +54,7 @@ function normalizeDateString(
     template: string,
     separator: string,
 ): string {
-    const dateSegments = dateString.split(/\D/).filter(str => str);
+    const dateSegments = dateString.split(/\D/).filter(Boolean);
     const templateSegments = template.split(separator);
     const normalizedSegments = dateSegments.map((segment, index) =>
         index === templateSegments.length - 1


### PR DESCRIPTION
Closes https://github.com/taiga-family/maskito/issues/1176
Closes https://github.com/taiga-family/maskito/issues/836

Done:
1. Fixed `Date` formatting errors with those date modes: `mm/yyyy`, `yyyy/mm`, `mm/yy`
2. Added `integration tests` for those error cases