### PR TITLE
fix(kit): `Number` should drop decimal separator if all digits are erased

### DIFF
--- a/projects/demo-integrations/src/tests/component-testing/number/alone-decimal-separator.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/number/alone-decimal-separator.cy.ts
@@ -1,0 +1,55 @@
+import {maskitoNumberOptionsGenerator} from '@maskito/kit';
+
+import {TestInput} from '../utils';
+
+describe('Number | should drop decimal separator if all digits are erased', () => {
+    beforeEach(() => {
+        cy.mount(TestInput, {
+            componentProperties: {
+                maskitoOptions: maskitoNumberOptionsGenerator({
+                    precision: 2,
+                    minusSign: '-',
+                }),
+            },
+        });
+        cy.get('input').focus().should('have.value', '');
+    });
+
+    it('empty integer part & NOT empty decimal part => keeps decimal separator untouched', () => {
+        cy.get('input')
+            .type('0.12')
+            .type('{backspace}'.repeat(2))
+            .should('have.value', '0.');
+    });
+
+    it('NOT empty integer part & empty decimal part => keeps decimal separator untouched', () => {
+        cy.get('input')
+            .type('0.12')
+            .type('{moveToStart}')
+            .type('{del}')
+            .should('have.value', '.12');
+    });
+
+    describe('empty integer part & empty decimal part => drops decimal separator', () => {
+        [
+            {minusSign: '', testTitle: 'Without minus'},
+            {minusSign: '-', testTitle: 'With minus'},
+        ].forEach(({testTitle, minusSign}) => {
+            it(testTitle, () => {
+                cy.get('input')
+                    .type(`${minusSign}0.12`)
+                    .type('{backspace}'.repeat(2))
+                    .type(`{moveToStart}${'{rightArrow}'.repeat(minusSign.length)}`)
+                    .type('{del}')
+                    .should('have.value', minusSign)
+                    // and then repeat everything in reversed order
+                    .type('0.12')
+                    .type(`{moveToStart}${'{rightArrow}'.repeat(minusSign.length)}`)
+                    .type('{del}')
+                    .type('{moveToEnd}')
+                    .type('{backspace}'.repeat(2))
+                    .should('have.value', minusSign);
+            });
+        });
+    });
+});

--- a/projects/kit/src/lib/masks/number/processors/empty-postprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/empty-postprocessor.ts
@@ -28,11 +28,14 @@ export function emptyPostprocessor({
             cleanValue,
             decimalSeparator,
         );
+        const aloneDecimalSeparator =
+            !integerPart && !decimalPart && cleanValue.includes(decimalSeparator);
 
         if (
-            !integerPart &&
-            !Number(decimalPart) &&
-            caretIndex === (minus + extractedPrefix).length
+            (!integerPart &&
+                !Number(decimalPart) &&
+                caretIndex === (minus + extractedPrefix).length) ||
+            aloneDecimalSeparator
         ) {
             return {
                 selection,


### PR DESCRIPTION
Closes #332
