### PR TITLE
chore: remove `git add` command from `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,12 +69,10 @@
     "lint-staged": {
         "*.{js,ts,html,md,less,json,svg,yml}": [
             "npm run lint -- --fix",
-            "prettier --write",
-            "git add"
+            "prettier --write"
         ],
         "*.less": [
-            "stylelint --fix",
-            "git add"
+            "stylelint --fix"
         ]
     },
     "prettier": "@taiga-ui/prettier-config",


### PR DESCRIPTION
# Previous behaviour

```shell
> git commit -m "chore: any commit message"
⚠ Some of your tasks use `git add` command.
Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```

# New behavior
No warning
Learn body of the following PR to get more details:
* https://github.com/taiga-family/taiga-ui/pull/3559