### PR TITLE
fix(react): revert mistakenly fixated `react` & `react-demo` peer-dependencies to just `>=16.8`

### DIFF
--- a/projects/react/package.json
+++ b/projects/react/package.json
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {
         "@maskito/core": "^2.3.1",
-        "react": ">=18.2.0",
-        "react-dom": ">=18.2.0"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
     }
 }


### PR DESCRIPTION
Revert these PRs:
* https://github.com/taiga-family/maskito/pull/1155
* https://github.com/taiga-family/maskito/pull/1156