### PR TITLE
fix(vue): revert mistakenly fixated `vue` peer-dependency to just `>=3.0.0`

### DIFF
--- a/projects/vue/package.json
+++ b/projects/vue/package.json
@@ -35,6 +35,6 @@
     },
     "peerDependencies": {
         "@maskito/core": "^2.3.1",
-        "vue": ">=3.4.22"
+        "vue": ">=3.0.0"
     }
 }


### PR DESCRIPTION
Revert this PR:
* https://github.com/taiga-family/maskito/pull/1181
