### PR TITLE
chore: drop `rollup-plugin-typescript2` from `overrides` of root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
         "yarn": "Please use npm instead of yarn to install dependencies"
     },
     "overrides": {
-        "rollup-plugin-typescript2": "0.36.0",
         "highlight.js": "11.5.1",
         "eslint-plugin-prettier": "5.1.3"
     },


### PR DESCRIPTION
Explore body of this PR:
* https://github.com/nrwl/nx/pull/20609

This bugfix was released in `Nx@18`.

We've already updated Nx to `18.3.5` – we can drop this legacy hack.
https://github.com/taiga-family/maskito/blob/28740ed866540f4db8bd597ee058c792ca2b94b1/package.json#L100
