### PR TITLE
chore(deps): fix renovate error `Could not resolve dependency`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
             "version": "2.4.0",
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "workspaces": [
-                "projects/*"
-            ],
+            "workspaces": ["projects/*"],
             "devDependencies": {
                 "@angular-devkit/build-angular": "15.2.10",
                 "@angular-devkit/core": "15.2.10",
@@ -325,14 +323,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.8.tgz",
             "integrity": "sha512-0/rb91GYKhrtbeglJXOhAv9RuYimgI8h623TplY2X+vA4EXnk3Zj1fXZreJ0J3OJJu1bwmb0W7g+2cT/d8/l/w==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -341,14 +335,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.8.tgz",
             "integrity": "sha512-oa/N5j6v1svZQs7EIRPqR8f+Bf8g6HBDjD/xHC02radE/NjKHK7oQmtmLxPs1iVwYyvE+Kolo6lbpfEQ9xnhxQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -357,14 +347,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.8.tgz",
             "integrity": "sha512-bTliMLqD7pTOoPg4zZkXqCDuzIUguEWLpeqkNfC41ODBHwoUgZ2w5JBeYimv4oP6TDVocoYmEhZrCLQTrH89bg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -373,14 +359,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.8.tgz",
             "integrity": "sha512-ghAbV3ia2zybEefXRRm7+lx8J/rnupZT0gp9CaGy/3iolEXkJ6LYRq4IpQVI9zR97ID80KJVoUlo3LSeA/sMAg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -389,14 +371,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.8.tgz",
             "integrity": "sha512-n5WOpyvZ9TIdv2V1K3/iIkkJeKmUpKaCTdun9buhGRWfH//osmUjlv4Z5mmWdPWind/VGcVxTHtLfLCOohsOXw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -405,14 +383,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.8.tgz",
             "integrity": "sha512-a/SATTaOhPIPFWvHZDoZYgxaZRVHn0/LX1fHLGfZ6C13JqFUZ3K6SMD6/HCtwOQ8HnsNaEeokdiDSFLuizqv5A==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -421,14 +395,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.8.tgz",
             "integrity": "sha512-xpFJb08dfXr5+rZc4E+ooZmayBW6R3q59daCpKZ/cDU96/kvDM+vkYzNeTJCGd8rtO6fHWMq5Rcv/1cY6p6/0Q==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -437,14 +407,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.8.tgz",
             "integrity": "sha512-6Ij8gfuGszcEwZpi5jQIJCVIACLS8Tz2chnEBfYjlmMzVsfqBP1iGmHQPp7JSnZg5xxK9tjCc+pJ2WtAmPRFVA==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -453,14 +419,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.8.tgz",
             "integrity": "sha512-v3iwDQuDljLTxpsqQDl3fl/yihjPAyOguxuloON9kFHYwopeJEf1BkDXODzYyXEI19gisEsQlG1bM65YqKSIww==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -469,14 +431,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.8.tgz",
             "integrity": "sha512-8svILYKhE5XetuFk/B6raFYIyIqydQi+GngEXJgdPdI7OMKUbSd7uzR02wSY4kb53xBrClLkhH4Xs8P61Q2BaA==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -485,14 +443,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.8.tgz",
             "integrity": "sha512-B6FyMeRJeV0NpyEOYlm5qtQfxbdlgmiGdD+QsipzKfFky0K5HW5Td6dyK3L3ypu1eY4kOmo7wW0o94SBqlqBSA==",
-            "cpu": [
-                "loong64"
-            ],
+            "cpu": ["loong64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -501,14 +455,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.8.tgz",
             "integrity": "sha512-CCb67RKahNobjm/eeEqeD/oJfJlrWyw29fgiyB6vcgyq97YAf3gCOuP6qMShYSPXgnlZe/i4a8WFHBw6N8bYAA==",
-            "cpu": [
-                "mips64el"
-            ],
+            "cpu": ["mips64el"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -517,14 +467,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.8.tgz",
             "integrity": "sha512-bytLJOi55y55+mGSdgwZ5qBm0K9WOCh0rx+vavVPx+gqLLhxtSFU0XbeYy/dsAAD6xECGEv4IQeFILaSS2auXw==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -533,14 +479,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.8.tgz",
             "integrity": "sha512-2YpRyQJmKVBEHSBLa8kBAtbhucaclb6ex4wchfY0Tj3Kg39kpjeJ9vhRU7x4mUpq8ISLXRXH1L0dBYjAeqzZAw==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -549,14 +491,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.8.tgz",
             "integrity": "sha512-QgbNY/V3IFXvNf11SS6exkpVcX0LJcob+0RWCgV9OiDAmVElnxciHIisoSix9uzYzScPmS6dJFbZULdSAEkQVw==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -565,14 +503,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.8.tgz",
             "integrity": "sha512-mM/9S0SbAFDBc4OPoyP6SEOo5324LpUxdpeIUUSrSTOfhHU9hEfqRngmKgqILqwx/0DVJBzeNW7HmLEWp9vcOA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -581,14 +515,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.8.tgz",
             "integrity": "sha512-eKUYcWaWTaYr9zbj8GertdVtlt1DTS1gNBWov+iQfWuWyuu59YN6gSEJvFzC5ESJ4kMcKR0uqWThKUn5o8We6Q==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "netbsd"
-            ],
+            "os": ["netbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -597,14 +527,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.8.tgz",
             "integrity": "sha512-Vc9J4dXOboDyMXKD0eCeW0SIeEzr8K9oTHJU+Ci1mZc5njPfhKAqkRt3B/fUNU7dP+mRyralPu8QUkiaQn7iIg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "openbsd"
-            ],
+            "os": ["openbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -613,14 +539,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.8.tgz",
             "integrity": "sha512-0xvOTNuPXI7ft1LYUgiaXtpCEjp90RuBBYovdd2lqAFxje4sEucurg30M1WIm03+3jxByd3mfo+VUmPtRSVuOw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "sunos"
-            ],
+            "os": ["sunos"],
             "engines": {
                 "node": ">=12"
             }
@@ -629,14 +551,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.8.tgz",
             "integrity": "sha512-G0JQwUI5WdEFEnYNKzklxtBheCPkuDdu1YrtRrjuQv30WsYbkkoixKxLLv8qhJmNI+ATEWquZe/N0d0rpr55Mg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -645,14 +563,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.8.tgz",
             "integrity": "sha512-Fqy63515xl20OHGFykjJsMnoIWS+38fqfg88ClvPXyDbLtgXal2DTlhb1TfTX34qWi3u4I7Cq563QcHpqgLx8w==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -661,14 +575,10 @@
             "version": "0.17.8",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.8.tgz",
             "integrity": "sha512-1iuezdyDNngPnz8rLRDO2C/ZZ/emJLb72OsZeqQ6gL6Avko/XCXZw+NuxBSNhBAP13Hie418V7VMt9et1FMvpg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -1603,11 +1513,11 @@
             "dev": true
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.6.tgz",
-            "integrity": "sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "dependencies": {
-                "@babel/highlight": "^7.24.6",
+                "@babel/highlight": "^7.24.7",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -1615,28 +1525,28 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.6.tgz",
-            "integrity": "sha512-aC2DGhBq5eEdyXWqrDInSqQjO0k8xtPRf5YylULqx8MCd6jBtzqfta/3ETMRpuKIc5hyswfO80ObyA1MvkCcUQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+            "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.6.tgz",
-            "integrity": "sha512-qAHSfAdVyFmIvl0VHELib8xar7ONuSHrE2hLnsaWkYNTI68dmi1x8GYDhJjMI/e7XWal9QBlZkwbOnkcw7Z8gQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+            "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.24.6",
-                "@babel/generator": "^7.24.6",
-                "@babel/helper-compilation-targets": "^7.24.6",
-                "@babel/helper-module-transforms": "^7.24.6",
-                "@babel/helpers": "^7.24.6",
-                "@babel/parser": "^7.24.6",
-                "@babel/template": "^7.24.6",
-                "@babel/traverse": "^7.24.6",
-                "@babel/types": "^7.24.6",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.24.7",
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helpers": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/template": "^7.24.7",
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -1652,11 +1562,11 @@
             }
         },
         "node_modules/@babel/core/node_modules/@babel/generator": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.6.tgz",
-            "integrity": "sha512-S7m4eNa6YAPJRHmKsLHIDJhNAGNKoWNiWefz1MBbpnt8g9lvMDl1hir4P9bo/57bQEmuwEhnRU/AMWsD0G/Fbg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
             "dependencies": {
-                "@babel/types": "^7.24.6",
+                "@babel/types": "^7.24.7",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -1666,13 +1576,13 @@
             }
         },
         "node_modules/@babel/core/node_modules/@babel/template": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.6.tgz",
-            "integrity": "sha512-3vgazJlLwNXi9jhrR1ef8qiB65L1RK90+lEQwv4OxveHnqC3BfmnHdgySwRLzf6akhlOYenT+b7AfWq+a//AHw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dependencies": {
-                "@babel/code-frame": "^7.24.6",
-                "@babel/parser": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1705,9 +1615,9 @@
             }
         },
         "node_modules/@babel/eslint-parser": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.6.tgz",
-            "integrity": "sha512-Q1BfQX42zXHx732PLW0w4+Y3wJjoZKEMaatFUEAmQ7Z+jCXxinzeqX9bvv2Q8xNPes/H6F0I23oGkcgjaItmLw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.7.tgz",
+            "integrity": "sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==",
             "dev": true,
             "dependencies": {
                 "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -1732,9 +1642,9 @@
             }
         },
         "node_modules/@babel/eslint-plugin": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.24.6.tgz",
-            "integrity": "sha512-sUDNpeOID2Am4cBXEmyhRaSvwwXIHVaG7trk7HO1Ri5VrEIBPYXg4ulTvZm2Lo0Y7u7Tw8QLe6JygchdOOto6w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.24.7.tgz",
+            "integrity": "sha512-lODNPJnM+OfcxxBvdmI2YmUeC0fBK3k9yET5O+1Eukr8d5VpO19c6ARtNheE2t2i/8XNYTzp3HeGEAAGZH3nnQ==",
             "dev": true,
             "dependencies": {
                 "eslint-rule-composer": "^0.3.0"
@@ -1788,24 +1698,25 @@
             }
         },
         "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.24.6.tgz",
-            "integrity": "sha512-+wnfqc5uHiMYtvRX7qu80Toef8BXeh4HHR1SPeonGb1SKPniNEd4a/nlaJJMv/OIEYvIVavvo0yR7u10Gqz0Iw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.24.7.tgz",
+            "integrity": "sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.6.tgz",
-            "integrity": "sha512-VZQ57UsDGlX/5fFA7GkVPplZhHsVc+vuErWgdOiysI9Ksnw0Pbbd6pnPiR/mmJyKHgyIW0c7KT32gmhiF+cirg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+            "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
             "dependencies": {
-                "@babel/compat-data": "^7.24.6",
-                "@babel/helper-validator-option": "^7.24.6",
+                "@babel/compat-data": "^7.24.7",
+                "@babel/helper-validator-option": "^7.24.7",
                 "browserslist": "^4.22.2",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -1815,9 +1726,9 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1833,10 +1744,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -1854,19 +1765,19 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.6.tgz",
-            "integrity": "sha512-djsosdPJVZE6Vsw3kk7IPRWethP94WHGOhQTc67SNXE0ZzMhHgALw8iGmYS0TD1bbMM0VDROy43od7/hN6WYcA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.7.tgz",
+            "integrity": "sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-function-name": "^7.24.6",
-                "@babel/helper-member-expression-to-functions": "^7.24.6",
-                "@babel/helper-optimise-call-expression": "^7.24.6",
-                "@babel/helper-replace-supers": "^7.24.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.6",
-                "@babel/helper-split-export-declaration": "^7.24.6",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-member-expression-to-functions": "^7.24.7",
+                "@babel/helper-optimise-call-expression": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1877,24 +1788,24 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.6.tgz",
-            "integrity": "sha512-CvLSkwXGWnYlF9+J3iZUvwgAxKiYzK3BWuo+mLzD/MDGOZDj7Gq8+hqaOkMxmJwmlv0iu86uH5fdADd9Hxkymw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1910,12 +1821,12 @@
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.24.6.tgz",
-            "integrity": "sha512-C875lFBIWWwyv6MHZUG9HmRrlTDgOsLWZfYR0nW69gaKJNe0/Mpxx5r0EID2ZdHQkdUmQo2t0uNckTL08/1BgA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.24.7.tgz",
+            "integrity": "sha512-03TCmXy2FtXJEZfbXDTSqq1fRJArk7lX9DOFC/47VthYcxyIOx+eXQmdo6DOQvrbpIix+KfXwvuXdFDZHxt+rA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
                 "regexpu-core": "^5.3.1",
                 "semver": "^6.3.1"
             },
@@ -1927,12 +1838,12 @@
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1974,82 +1885,87 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.6.tgz",
-            "integrity": "sha512-Y50Cg3k0LKLMjxdPjIl40SdJgMB85iXn27Vk/qbHZCFx/o5XO3PSnpi675h1KEmmDb6OFArfd5SCQEQ5Q4H88g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+            "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+            "dependencies": {
+                "@babel/types": "^7.24.7"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.6.tgz",
-            "integrity": "sha512-xpeLqeeRkbxhnYimfr2PC+iA0Q7ljX/d1eZ9/inYbmfG2jpl8Lu3DyXvpOAnrS5kxkfOWJjioIMQsaMBXFI05w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
             "dependencies": {
-                "@babel/template": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name/node_modules/@babel/template": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.6.tgz",
-            "integrity": "sha512-3vgazJlLwNXi9jhrR1ef8qiB65L1RK90+lEQwv4OxveHnqC3BfmnHdgySwRLzf6akhlOYenT+b7AfWq+a//AHw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dependencies": {
-                "@babel/code-frame": "^7.24.6",
-                "@babel/parser": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.6.tgz",
-            "integrity": "sha512-SF/EMrC3OD7dSta1bLJIlrsVxwtd0UpjRJqLno6125epQMJ/kyFmpTT4pbvPbdQHzCHg+biQ7Syo8lnDtbR+uA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.6.tgz",
-            "integrity": "sha512-OTsCufZTxDUsv2/eDXanw/mUZHWOxSbEmC3pP8cgjcy5rgeVPWWMStnv274DV60JtHxTk0adT0QrCzC4M9NWGg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.7.tgz",
+            "integrity": "sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.6.tgz",
-            "integrity": "sha512-a26dmxFJBF62rRO9mmpgrfTLsAuyHk4e1hKTUkD/fcMfynt8gvEKwQPQDVxWhca8dHoDck+55DFt42zV0QMw5g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.6.tgz",
-            "integrity": "sha512-Y/YMPm83mV2HJTbX1Qh2sjgjqcacvOlhbzdCCsSlblOKjSYmQqEbO6rUniWQyRo9ncyfjT8hnUjlG06RXDEmcA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+            "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-module-imports": "^7.24.6",
-                "@babel/helper-simple-access": "^7.24.6",
-                "@babel/helper-split-export-declaration": "^7.24.6",
-                "@babel/helper-validator-identifier": "^7.24.6"
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-simple-access": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2059,45 +1975,45 @@
             }
         },
         "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.6.tgz",
-            "integrity": "sha512-CvLSkwXGWnYlF9+J3iZUvwgAxKiYzK3BWuo+mLzD/MDGOZDj7Gq8+hqaOkMxmJwmlv0iu86uH5fdADd9Hxkymw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.6.tgz",
-            "integrity": "sha512-3SFDJRbx7KuPRl8XDUr8O7GAEB8iGyWPjLKJh/ywP/Iy9WOmEfMrsWbaZpvBu2HSYn4KQygIsz0O7m8y10ncMA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+            "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.6.tgz",
-            "integrity": "sha512-MZG/JcWfxybKwsA9N9PmtF2lOSFSEMVCpIRrbxccZFLJPrJciJdG/UhSh5W96GEteJI2ARqm5UAHxISwRDLSNg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+            "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-remap-async-to-generator": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.24.6.tgz",
-            "integrity": "sha512-1Qursq9ArRZPAMOZf/nuzVW8HgJLkTB9y9LfP4lW2MVp4e9WkLJDovfKBxoDcCk6VuzIxyqWHyBoaCtSRP10yg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.24.7.tgz",
+            "integrity": "sha512-9pKLcTlZ92hNZMQfGCHImUpDOlAgkkpqalWEeftW5FBya75k8Li2ilerxkM/uBEj01iBZXcCIB/bwvDYgWyibA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-wrap-function": "^7.24.6"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-wrap-function": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2107,26 +2023,26 @@
             }
         },
         "node_modules/@babel/helper-remap-async-to-generator/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.6.tgz",
-            "integrity": "sha512-mRhfPwDqDpba8o1F8ESxsEkJMQkUF8ZIWrAc0FtWhxnjfextxMWxr22RtFizxxSYLjVHDeMgVsRq8BBZR2ikJQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.7.tgz",
+            "integrity": "sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-member-expression-to-functions": "^7.24.6",
-                "@babel/helper-optimise-call-expression": "^7.24.6"
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-member-expression-to-functions": "^7.24.7",
+                "@babel/helper-optimise-call-expression": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2136,23 +2052,25 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.6.tgz",
-            "integrity": "sha512-nZzcMMD4ZhmB35MOOzQuiGO5RzL6tJbsT37Zx8M5L/i9KSrukGXWTjLe1knIbb/RmxoJE9GON9soq0c0VEMM5g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+            "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.6.tgz",
-            "integrity": "sha512-jhbbkK3IUKc4T43WadP96a27oYti9gEf1LdyGSP2rHGH77kwLwfhO7TgwnWvxxQVmke0ImmCSS47vcuxEMGD3Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+            "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2171,88 +2089,89 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.6.tgz",
-            "integrity": "sha512-WdJjwMEkmBicq5T9fm/cHND3+UlFa2Yj8ALLgmoSQAJZysYbBjw+azChSGPN4DSPLXOcooGRvDwZWMcF/mLO2Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
-            "integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.6.tgz",
-            "integrity": "sha512-Jktc8KkF3zIkePb48QO+IapbXlSapOW9S+ogZZkcO6bABgYAxtZcjZ/O005111YLf+j4M84uEgwYoidDkXbCkQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+            "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.6.tgz",
-            "integrity": "sha512-f1JLrlw/jbiNfxvdrfBgio/gRBk3yTAEJWirpAkiJG2Hb22E7cEYKHWo0dFPTv/niPovzIdPdEDetrv6tC6gPQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.24.7.tgz",
+            "integrity": "sha512-N9JIYk3TD+1vq/wn77YnJOqMtfWhNewNE+DJV4puD2X7Ew9J4JvrzrFDfTfyv5EgEXVy9/Wt8QiOErzEmv5Ifw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-function-name": "^7.24.6",
-                "@babel/template": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/template": "^7.24.7",
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-wrap-function/node_modules/@babel/template": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.6.tgz",
-            "integrity": "sha512-3vgazJlLwNXi9jhrR1ef8qiB65L1RK90+lEQwv4OxveHnqC3BfmnHdgySwRLzf6akhlOYenT+b7AfWq+a//AHw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.6",
-                "@babel/parser": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.6.tgz",
-            "integrity": "sha512-V2PI+NqnyFu1i0GyTd/O/cTpxzQCYioSkUIRmgo7gFEHKKCg5w46+r/A6WeUR1+P3TeQ49dspGPNd/E3n9AnnA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+            "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
             "dependencies": {
-                "@babel/template": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers/node_modules/@babel/template": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.6.tgz",
-            "integrity": "sha512-3vgazJlLwNXi9jhrR1ef8qiB65L1RK90+lEQwv4OxveHnqC3BfmnHdgySwRLzf6akhlOYenT+b7AfWq+a//AHw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dependencies": {
-                "@babel/code-frame": "^7.24.6",
-                "@babel/parser": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.6.tgz",
-            "integrity": "sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.6",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -2262,9 +2181,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.6.tgz",
-            "integrity": "sha512-eNZXdfU35nJC2h24RznROuOpO94h6x8sg9ju0tT9biNtLZ2vuP8SduLqqV+/8+cebSLV9SJEAN5Z3zQbJG/M+Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -2273,13 +2192,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.6.tgz",
-            "integrity": "sha512-bYndrJ6Ph6Ar+GaB5VAc0JPoP80bQCm4qon6JEzXfRl5QZyQ8Ur1K6k7htxWmPA5z+k7JQvaMUrtXlqclWYzKw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.24.7.tgz",
+            "integrity": "sha512-TiT1ss81W80eQsN+722OaeQMY/G4yTb4G9JrqeiDADs3N8lbPMGldWi9x8tyqCW5NLx1Jh2AvkE6r6QvEltMMQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2289,12 +2208,12 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.6.tgz",
-            "integrity": "sha512-iVuhb6poq5ikqRq2XWU6OQ+R5o9wF+r/or9CeUyovgptz0UlnK4/seOQ1Istu/XybYjAhQv1FRSSfHHufIku5Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.7.tgz",
+            "integrity": "sha512-unaQgZ/iRu/By6tsjMZzpeBZjChYfLYry6HrEXPoz3KmfF0sVBQ1l8zKMQ4xRGLWVsjuvB8nQfjNP/DcfEOCsg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2304,14 +2223,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.6.tgz",
-            "integrity": "sha512-c8TER5xMDYzzFcGqOEp9l4hvB7dcbhcGjcLVwxWfe4P5DOafdwjsBJZKsmv+o3aXh7NhopvayQIovHrh2zSRUQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.7.tgz",
+            "integrity": "sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.6",
-                "@babel/plugin-transform-optional-chaining": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+                "@babel/plugin-transform-optional-chaining": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2321,13 +2240,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.6.tgz",
-            "integrity": "sha512-z8zEjYmwBUHN/pCF3NuWBhHQjJCrd33qAi8MgANfMrAvn72k2cImT8VjK9LJFu4ysOLJqhfkYYb3MvwANRUNZQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.24.7.tgz",
+            "integrity": "sha512-utA4HuR6F4Vvcr+o4DnjL8fCOlgRFGbeeBEGNg3ZTrLFw6VWG5XmUrvcQ0FjIYMU2ST4XcR2Wsp7t9qOAPnxMg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2391,14 +2310,14 @@
             }
         },
         "node_modules/@babel/plugin-proposal-decorators": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.24.6.tgz",
-            "integrity": "sha512-8DjR0/DzlBhz2SVi9a19/N2U5+C3y3rseXuyoKL9SP8vnbewscj1eHZtL6kpEn4UCuUmqEo0mvqyDYRFoN2gpA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.24.7.tgz",
+            "integrity": "sha512-RL9GR0pUG5Kc8BUWLNDm2T5OpYwSX15r98I0IkgmRQTXuELq/OynH8xtMTMvTJFjXbMWFVTKtYkTaYQsuAwQlQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/plugin-syntax-decorators": "^7.24.6"
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/plugin-syntax-decorators": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2666,12 +2585,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-decorators": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.24.6.tgz",
-            "integrity": "sha512-gInH8LEqBp+wkwTVihCd/qf+4s28g81FZyvlIbAurHk9eSiItEKG7E0uNK2UdpgsD79aJVAW3R3c85h0YJ0jsw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.24.7.tgz",
+            "integrity": "sha512-Ui4uLJJrRV1lb38zg1yYTmRKmiZLiftDEvZN2iq3kd9kUFU+PttmzTbAFC2ucRk/XJmtek6G23gPsuZbhrT8fQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2705,12 +2624,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.6.tgz",
-            "integrity": "sha512-BE6o2BogJKJImTmGpkmOic4V0hlRRxVtzqxiSPa8TIFxyhi4EFjHm08nq1M4STK4RytuLMgnSz0/wfflvGFNOg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.7.tgz",
+            "integrity": "sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2720,12 +2639,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.6.tgz",
-            "integrity": "sha512-D+CfsVZousPXIdudSII7RGy52+dYRtbyKAZcvtQKq/NpsivyMVduepzcLqG5pMBugtMdedxdC8Ramdpcne9ZWQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
+            "integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2757,12 +2676,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.6.tgz",
-            "integrity": "sha512-lWfvAIFNWMlCsU0DRUun2GpFwZdGTukLaHJqRh1JRb80NdAP5Sb1HDHB5X9P9OtgZHQl089UzQkpYlBq2VTPRw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+            "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2867,12 +2786,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.6.tgz",
-            "integrity": "sha512-TzCtxGgVTEJWWwcYwQhCIQ6WaKlo80/B+Onsk4RRCcYqpYGFcG9etPW94VToGte5AAcxRrhjPUFvUS3Y2qKi4A==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
+            "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2898,12 +2817,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.6.tgz",
-            "integrity": "sha512-jSSSDt4ZidNMggcLx8SaKsbGNEfIl0PHx/4mFEulorE7bpYLbN0d3pDW3eJ7Y5Z3yPhy3L3NaPCYyTUY7TuugQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.7.tgz",
+            "integrity": "sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2913,14 +2832,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.6.tgz",
-            "integrity": "sha512-VEP2o4iR2DqQU6KPgizTW2mnMx6BG5b5O9iQdrW9HesLkv8GIA8x2daXBQxw1MrsIkFQGA/iJ204CKoQ8UcnAA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.7.tgz",
+            "integrity": "sha512-o+iF77e3u7ZS4AoAuJvapz9Fm001PuD2V3Lp6OSE4FYQke+cSewYtnek+THqGRWyQloRCyvWL1OkyfNEl9vr/g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-remap-async-to-generator": "^7.24.6",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-remap-async-to-generator": "^7.24.7",
                 "@babel/plugin-syntax-async-generators": "^7.8.4"
             },
             "engines": {
@@ -2948,12 +2867,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.6.tgz",
-            "integrity": "sha512-XNW7jolYHW9CwORrZgA/97tL/k05qe/HL0z/qqJq1mdWhwwCM6D4BJBV7wAz9HgFziN5dTOG31znkVIzwxv+vw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.7.tgz",
+            "integrity": "sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2963,12 +2882,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.6.tgz",
-            "integrity": "sha512-S/t1Xh4ehW7sGA7c1j/hiOBLnEYCp/c2sEG4ZkL8kI1xX9tW2pqJTCHKtdhe/jHKt8nG0pFCrDHUXd4DvjHS9w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.7.tgz",
+            "integrity": "sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2978,13 +2897,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-properties": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.6.tgz",
-            "integrity": "sha512-j6dZ0Z2Z2slWLR3kt9aOmSIrBvnntWjMDN/TVcMPxhXMLmJVqX605CBRlcGI4b32GMbfifTEsdEjGjiE+j/c3A==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
+            "integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2994,13 +2913,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-static-block": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.6.tgz",
-            "integrity": "sha512-1QSRfoPI9RoLRa8Mnakc6v3e0gJxiZQTYrMfLn+mD0sz5+ndSzwymp2hDcYJTyT0MOn0yuWzj8phlIvO72gTHA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.7.tgz",
+            "integrity": "sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-class-static-block": "^7.14.5"
             },
             "engines": {
@@ -3011,18 +2930,18 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.6.tgz",
-            "integrity": "sha512-+fN+NO2gh8JtRmDSOB6gaCVo36ha8kfCW1nMq2Gc0DABln0VcHN4PrALDvF5/diLzIRKptC7z/d7Lp64zk92Fg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.7.tgz",
+            "integrity": "sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-compilation-targets": "^7.24.6",
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-function-name": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-replace-supers": "^7.24.6",
-                "@babel/helper-split-export-declaration": "^7.24.6",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -3033,37 +2952,37 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-classes/node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.6.tgz",
-            "integrity": "sha512-CvLSkwXGWnYlF9+J3iZUvwgAxKiYzK3BWuo+mLzD/MDGOZDj7Gq8+hqaOkMxmJwmlv0iu86uH5fdADd9Hxkymw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.6.tgz",
-            "integrity": "sha512-cRzPobcfRP0ZtuIEkA8QzghoUpSB3X3qSH5W2+FzG+VjWbJXExtx0nbRqwumdBN1x/ot2SlTNQLfBCnPdzp6kg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.7.tgz",
+            "integrity": "sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/template": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/template": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3073,26 +2992,26 @@
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties/node_modules/@babel/template": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.6.tgz",
-            "integrity": "sha512-3vgazJlLwNXi9jhrR1ef8qiB65L1RK90+lEQwv4OxveHnqC3BfmnHdgySwRLzf6akhlOYenT+b7AfWq+a//AHw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.6",
-                "@babel/parser": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.6.tgz",
-            "integrity": "sha512-YLW6AE5LQpk5npNXL7i/O+U9CE4XsBCuRPgyjl1EICZYKmcitV+ayuuUGMJm2lC1WWjXYszeTnIxF/dq/GhIZQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.7.tgz",
+            "integrity": "sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3102,13 +3021,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.6.tgz",
-            "integrity": "sha512-rCXPnSEKvkm/EjzOtLoGvKseK+dS4kZwx1HexO3BtRtgL0fQ34awHn34aeSHuXtZY2F8a1X8xqBBPRtOxDVmcA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.7.tgz",
+            "integrity": "sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3118,12 +3037,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.6.tgz",
-            "integrity": "sha512-/8Odwp/aVkZwPFJMllSbawhDAO3UJi65foB00HYnK/uXvvCPm0TAXSByjz1mpRmp0q6oX2SIxpkUOpPFHk7FLA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.7.tgz",
+            "integrity": "sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3133,12 +3052,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-dynamic-import": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.6.tgz",
-            "integrity": "sha512-vpq8SSLRTBLOHUZHSnBqVo0AKX3PBaoPs2vVzYVWslXDTDIpwAcCDtfhUcHSQQoYoUvcFPTdC8TZYXu9ZnLT/w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.7.tgz",
+            "integrity": "sha512-sc3X26PhZQDb3JhORmakcbvkeInvxz+A8oda99lj7J60QRuPZvNAk9wQlTBS1ZynelDrDmTU4pw1tyc5d5ZMUg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3"
             },
             "engines": {
@@ -3149,13 +3068,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.6.tgz",
-            "integrity": "sha512-EemYpHtmz0lHE7hxxxYEuTYOOBZ43WkDgZ4arQ4r+VX9QHuNZC+WH3wUWmRNvR8ECpTRne29aZV6XO22qpOtdA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.7.tgz",
+            "integrity": "sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3165,12 +3084,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-export-namespace-from": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.24.6.tgz",
-            "integrity": "sha512-inXaTM1SVrIxCkIJ5gqWiozHfFMStuGbGJAxZFBoHcRRdDP0ySLb3jH6JOwmfiinPwyMZqMBX+7NBDCO4z0NSA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.24.7.tgz",
+            "integrity": "sha512-v0K9uNYsPL3oXZ/7F9NNIbAj2jv1whUEtyA6aujhekLs56R++JDQuzRcP2/z4WX5Vg/c5lE9uWZA0/iUoFhLTA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
             },
             "engines": {
@@ -3181,13 +3100,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.6.tgz",
-            "integrity": "sha512-n3Sf72TnqK4nw/jziSqEl1qaWPbCRw2CziHH+jdRYvw4J6yeCzsj4jdw8hIntOEeDGTmHVe2w4MVL44PN0GMzg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.7.tgz",
+            "integrity": "sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3197,14 +3116,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.6.tgz",
-            "integrity": "sha512-sOajCu6V0P1KPljWHKiDq6ymgqB+vfo3isUS4McqW1DZtvSVU2v/wuMhmRmkg3sFoq6GMaUUf8W4WtoSLkOV/Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.7.tgz",
+            "integrity": "sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.24.6",
-                "@babel/helper-function-name": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3214,12 +3133,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-json-strings": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.6.tgz",
-            "integrity": "sha512-Uvgd9p2gUnzYJxVdBLcU0KurF8aVhkmVyMKW4MIY1/BByvs3EBpv45q01o7pRTVmTvtQq5zDlytP3dcUgm7v9w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.7.tgz",
+            "integrity": "sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-json-strings": "^7.8.3"
             },
             "engines": {
@@ -3230,12 +3149,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.6.tgz",
-            "integrity": "sha512-f2wHfR2HF6yMj+y+/y07+SLqnOSwRp8KYLpQKOzS58XLVlULhXbiYcygfXQxJlMbhII9+yXDwOUFLf60/TL5tw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.7.tgz",
+            "integrity": "sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3245,12 +3164,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.6.tgz",
-            "integrity": "sha512-EKaWvnezBCMkRIHxMJSIIylzhqK09YpiJtDbr2wsXTwnO0TxyjMUkaw4RlFIZMIS0iDj0KyIg7H7XCguHu/YDA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.7.tgz",
+            "integrity": "sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
             },
             "engines": {
@@ -3261,12 +3180,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.6.tgz",
-            "integrity": "sha512-9g8iV146szUo5GWgXpRbq/GALTnY+WnNuRTuRHWWFfWGbP9ukRL0aO/jpu9dmOPikclkxnNsjY8/gsWl6bmZJQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.7.tgz",
+            "integrity": "sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3276,13 +3195,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.6.tgz",
-            "integrity": "sha512-eAGogjZgcwqAxhyFgqghvoHRr+EYRQPFjUXrTYKBRb5qPnAVxOOglaxc4/byHqjvq/bqO2F3/CGwTHsgKJYHhQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.7.tgz",
+            "integrity": "sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3292,14 +3211,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.6.tgz",
-            "integrity": "sha512-JEV8l3MHdmmdb7S7Cmx6rbNEjRCgTQMZxllveHO0mx6uiclB0NflCawlQQ6+o5ZrwjUBYPzHm2XoK4wqGVUFuw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.7.tgz",
+            "integrity": "sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-simple-access": "^7.24.6"
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-simple-access": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3309,15 +3228,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.6.tgz",
-            "integrity": "sha512-xg1Z0J5JVYxtpX954XqaaAT6NpAY6LtZXvYFCJmGFJWwtlz2EmJoR8LycFRGNE8dBKizGWkGQZGegtkV8y8s+w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.7.tgz",
+            "integrity": "sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-hoist-variables": "^7.24.6",
-                "@babel/helper-module-transforms": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-validator-identifier": "^7.24.6"
+                "@babel/helper-hoist-variables": "^7.24.7",
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3327,13 +3246,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.6.tgz",
-            "integrity": "sha512-esRCC/KsSEUvrSjv5rFYnjZI6qv4R1e/iHQrqwbZIoRJqk7xCvEUiN7L1XrmW5QSmQe3n1XD88wbgDTWLbVSyg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.7.tgz",
+            "integrity": "sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3343,13 +3262,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.24.6.tgz",
-            "integrity": "sha512-6DneiCiu91wm3YiNIGDWZsl6GfTTbspuj/toTEqLh9d4cx50UIzSdg+T96p8DuT7aJOBRhFyaE9ZvTHkXrXr6Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.24.7.tgz",
+            "integrity": "sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3359,12 +3278,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.6.tgz",
-            "integrity": "sha512-f8liz9JG2Va8A4J5ZBuaSdwfPqN6axfWRK+y66fjKYbwf9VBLuq4WxtinhJhvp1w6lamKUwLG0slK2RxqFgvHA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.7.tgz",
+            "integrity": "sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3374,12 +3293,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.6.tgz",
-            "integrity": "sha512-+QlAiZBMsBK5NqrBWFXCYeXyiU1y7BQ/OYaiPAcQJMomn5Tyg+r5WuVtyEuvTbpV7L25ZSLfE+2E9ywj4FD48A==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.7.tgz",
+            "integrity": "sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
             },
             "engines": {
@@ -3390,12 +3309,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-numeric-separator": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.6.tgz",
-            "integrity": "sha512-6voawq8T25Jvvnc4/rXcWZQKKxUNZcKMS8ZNrjxQqoRFernJJKjE3s18Qo6VFaatG5aiX5JV1oPD7DbJhn0a4Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.7.tgz",
+            "integrity": "sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-numeric-separator": "^7.10.4"
             },
             "engines": {
@@ -3406,15 +3325,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.6.tgz",
-            "integrity": "sha512-OKmi5wiMoRW5Smttne7BwHM8s/fb5JFs+bVGNSeHWzwZkWXWValR1M30jyXo1s/RaqgwwhEC62u4rFH/FBcBPg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.7.tgz",
+            "integrity": "sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.24.6"
+                "@babel/plugin-transform-parameters": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3424,13 +3343,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.6.tgz",
-            "integrity": "sha512-N/C76ihFKlZgKfdkEYKtaRUtXZAgK7sOY4h2qrbVbVTXPrKGIi8aww5WGe/+Wmg8onn8sr2ut6FXlsbu/j6JHg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.7.tgz",
+            "integrity": "sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-replace-supers": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3440,12 +3359,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.6.tgz",
-            "integrity": "sha512-L5pZ+b3O1mSzJ71HmxSCmTVd03VOT2GXOigug6vDYJzE5awLI7P1g0wFcdmGuwSDSrQ0L2rDOe/hHws8J1rv3w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.7.tgz",
+            "integrity": "sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
             },
             "engines": {
@@ -3456,13 +3375,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.6.tgz",
-            "integrity": "sha512-cHbqF6l1QP11OkYTYQ+hhVx1E017O5ZcSPXk9oODpqhcAD1htsWG2NpHrrhthEO2qZomLK0FXS+u7NfrkF5aOQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.7.tgz",
+            "integrity": "sha512-tK+0N9yd4j+x/4hxF3F0e0fu/VdcxU18y5SevtyM/PCFlQvXbR0Zmlo2eBrKtVipGNFzpq56o8WsIIKcJFUCRQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             },
             "engines": {
@@ -3473,12 +3392,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.6.tgz",
-            "integrity": "sha512-ST7guE8vLV+vI70wmAxuZpIKzVjvFX9Qs8bl5w6tN/6gOypPWUmMQL2p7LJz5E63vEGrDhAiYetniJFyBH1RkA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.7.tgz",
+            "integrity": "sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3488,13 +3407,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.6.tgz",
-            "integrity": "sha512-T9LtDI0BgwXOzyXrvgLTT8DFjCC/XgWLjflczTLXyvxbnSR/gpv0hbmzlHE/kmh9nOvlygbamLKRo6Op4yB6aw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
+            "integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3504,14 +3423,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.6.tgz",
-            "integrity": "sha512-Qu/ypFxCY5NkAnEhCF86Mvg3NSabKsh/TPpBVswEdkGl7+FbsYHy1ziRqJpwGH4thBdQHh8zx+z7vMYmcJ7iaQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.7.tgz",
+            "integrity": "sha512-9z76mxwnwFxMyxZWEgdgECQglF2Q7cFLm0kMf8pGwt+GSJsY0cONKj/UuO4bOH0w/uAel3ekS4ra5CEAyJRmDA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-create-class-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
             },
             "engines": {
@@ -3522,24 +3441,24 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.6.tgz",
-            "integrity": "sha512-oARaglxhRsN18OYsnPTpb8TcKQWDYNsPNmTnx5++WOAsUJ0cSC/FZVlIJCKvPbU4yn/UXsS0551CFKJhN0CaMw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.7.tgz",
+            "integrity": "sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3549,12 +3468,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-constant-elements": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.6.tgz",
-            "integrity": "sha512-vQfyXRtG/kNIcTYRd/49uJnwvMig9X3R4XsTVXRml2RFupZFY+2RDuK+/ymb+MfX2WuIHAgUZc2xEvQrnI7QCg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.7.tgz",
+            "integrity": "sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3564,12 +3483,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.6.tgz",
-            "integrity": "sha512-/3iiEEHDsJuj9QU09gbyWGSUxDboFcD7Nj6dnHIlboWSodxXAoaY/zlNMHeYAC0WsERMqgO9a7UaM77CsYgWcg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
+            "integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3579,16 +3498,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.6.tgz",
-            "integrity": "sha512-pCtPHhpRZHfwdA5G1Gpk5mIzMA99hv0R8S/Ket50Rw+S+8hkt3wBWqdqHaPw0CuUYxdshUgsPiLQ5fAs4ASMhw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
+            "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-module-imports": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/plugin-syntax-jsx": "^7.24.6",
-                "@babel/types": "^7.24.6"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/plugin-syntax-jsx": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3598,12 +3517,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx-development": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.24.6.tgz",
-            "integrity": "sha512-F7EsNp5StNDouSSdYyDSxh4J+xvj/JqG+Cb6s2fA+jCyHOzigG5vTwgH8tU2U8Voyiu5zCG9bAK49wTr/wPH0w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.24.7.tgz",
+            "integrity": "sha512-QG9EnzoGn+Qar7rxuW+ZOsbWOt56FvvI93xInqsZDC5fsekx1AlIO4KIJ5M+D0p0SqSH156EpmZyXq630B8OlQ==",
             "dev": true,
             "dependencies": {
-                "@babel/plugin-transform-react-jsx": "^7.24.6"
+                "@babel/plugin-transform-react-jsx": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3613,25 +3532,25 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.24.6.tgz",
-            "integrity": "sha512-0HoDQlFJJkXRyV2N+xOpUETbKHcouSwijRQbKWVtxsPoq5bbB30qZag9/pSc5xcWVYjTHlLsBsY+hZDnzQTPNw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.24.7.tgz",
+            "integrity": "sha512-PLgBVk3fzbmEjBJ/u8kFzOqS9tUeDjiaWud/rRym/yjCo/M9cASPlnrd2ZmmZpQT40fOOrvR8jh+n8jikrOhNA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3641,24 +3560,24 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.6.tgz",
-            "integrity": "sha512-SMDxO95I8WXRtXhTAc8t/NFQUT7VYbIWwJCJgEli9ml4MhqUMh4S6hxgH6SmAC3eAQNWCDJFxcFeEt9w2sDdXg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.7.tgz",
+            "integrity": "sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "regenerator-transform": "^0.15.2"
             },
             "engines": {
@@ -3669,12 +3588,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.6.tgz",
-            "integrity": "sha512-DcrgFXRRlK64dGE0ZFBPD5egM2uM8mgfrvTMOSB2yKzOtjpGegVYkzh3s1zZg1bBck3nkXiaOamJUqK3Syk+4A==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.7.tgz",
+            "integrity": "sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3713,12 +3632,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.6.tgz",
-            "integrity": "sha512-xnEUvHSMr9eOWS5Al2YPfc32ten7CXdH7Zwyyk7IqITg4nX61oHj+GxpNvl+y5JHjfN3KXE2IV55wAWowBYMVw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.7.tgz",
+            "integrity": "sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3728,13 +3647,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.6.tgz",
-            "integrity": "sha512-h/2j7oIUDjS+ULsIrNZ6/TKG97FgmEk1PXryk/HQq6op4XUUUwif2f69fJrzK0wza2zjCS1xhXmouACaWV5uPA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.7.tgz",
+            "integrity": "sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3744,12 +3663,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.6.tgz",
-            "integrity": "sha512-fN8OcTLfGmYv7FnDrsjodYBo1DhPL3Pze/9mIIE2MGCT1KgADYIOD7rEglpLHZj8PZlC/JFX5WcD+85FLAQusw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.7.tgz",
+            "integrity": "sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3759,12 +3678,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.6.tgz",
-            "integrity": "sha512-BJbEqJIcKwrqUP+KfUIkxz3q8VzXe2R8Wv8TaNgO1cx+nNavxn/2+H8kp9tgFSOL6wYPPEgFvU6IKS4qoGqhmg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz",
+            "integrity": "sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3774,12 +3693,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.6.tgz",
-            "integrity": "sha512-IshCXQ+G9JIFJI7bUpxTE/oA2lgVLAIK8q1KdJNoPXOpvRaNjMySGuvLfBw/Xi2/1lLo953uE8hyYSDW3TSYig==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.7.tgz",
+            "integrity": "sha512-VtR8hDy7YLB7+Pet9IarXjg/zgCMSF+1mNS/EQEiEaUPoFXCVsHG64SIxcaaI2zJgRiv+YmgaQESUfWAdbjzgg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3789,15 +3708,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.6.tgz",
-            "integrity": "sha512-H0i+hDLmaYYSt6KU9cZE0gb3Cbssa/oxWis7PX4ofQzbvsfix9Lbh8SRk7LCPDlLWJHUiFeHU0qRRpF/4Zv7mQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.24.7.tgz",
+            "integrity": "sha512-iLD3UNkgx2n/HrjBesVbYX6j0yqn/sJktvbtKKgcaLIQ4bTTQ8obAypc1VpyHPD2y4Phh9zHOaAt8e/L14wCpw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.6",
-                "@babel/helper-create-class-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/plugin-syntax-typescript": "^7.24.6"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-create-class-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/plugin-syntax-typescript": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3807,24 +3726,24 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript/node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.6.tgz",
-            "integrity": "sha512-DitEzDfOMnd13kZnDqns1ccmftwJTS9DMkyn9pYTxulS7bZxUxpMly3Nf23QQ6NwA4UB8lAqjbqWtyvElEMAkg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.6.tgz",
-            "integrity": "sha512-bKl3xxcPbkQQo5eX9LjjDpU2xYHeEeNQbOhj0iPvetSzA+Tu9q/o5lujF4Sek60CM6MgYvOS/DJuwGbiEYAnLw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.7.tgz",
+            "integrity": "sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3834,13 +3753,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.6.tgz",
-            "integrity": "sha512-8EIgImzVUxy15cZiPii9GvLZwsy7Vxc+8meSlR3cXFmBIl5W5Tn9LGBf7CDKkHj4uVfNXCJB8RsVfnmY61iedA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.7.tgz",
+            "integrity": "sha512-uH2O4OV5M9FZYQrwc7NdVmMxQJOCCzFeYudlZSzUAHRFeOujQefa92E74TQDVskNHCzOXoigEuoyzHDhaEaK5w==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3850,13 +3769,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.6.tgz",
-            "integrity": "sha512-pssN6ExsvxaKU638qcWb81RrvvgZom3jDgU/r5xFZ7TONkZGFf4MhI2ltMb8OcQWhHyxgIavEU+hgqtbKOmsPA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.7.tgz",
+            "integrity": "sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3866,13 +3785,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.6.tgz",
-            "integrity": "sha512-quiMsb28oXWIDK0gXLALOJRXLgICLiulqdZGOaPPd0vRT7fQp74NtdADAVu+D8s00C+0Xs0MxVP0VKF/sZEUgw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.7.tgz",
+            "integrity": "sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6"
+                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3996,17 +3915,17 @@
             }
         },
         "node_modules/@babel/preset-react": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.24.6.tgz",
-            "integrity": "sha512-8mpzh1bWvmINmwM3xpz6ahu57mNaWavMm+wBNjQ4AFu1nghKBiIRET7l/Wmj4drXany/BBGjJZngICcD98F1iw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.24.7.tgz",
+            "integrity": "sha512-AAH4lEkpmzFWrGVlHaxJB7RLH21uPQ9+He+eFLWHmF9IuFQVugz8eAsamaW0DXRrTfco5zj1wWtpdcXJUOfsag==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-validator-option": "^7.24.6",
-                "@babel/plugin-transform-react-display-name": "^7.24.6",
-                "@babel/plugin-transform-react-jsx": "^7.24.6",
-                "@babel/plugin-transform-react-jsx-development": "^7.24.6",
-                "@babel/plugin-transform-react-pure-annotations": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-validator-option": "^7.24.7",
+                "@babel/plugin-transform-react-display-name": "^7.24.7",
+                "@babel/plugin-transform-react-jsx": "^7.24.7",
+                "@babel/plugin-transform-react-jsx-development": "^7.24.7",
+                "@babel/plugin-transform-react-pure-annotations": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4016,16 +3935,16 @@
             }
         },
         "node_modules/@babel/preset-typescript": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.6.tgz",
-            "integrity": "sha512-U10aHPDnokCFRXgyT/MaIRTivUu2K/mu0vJlwRS9LxJmJet+PFQNKpggPyFCUtC6zWSBPjvxjnpNkAn3Uw2m5w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
+            "integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-validator-option": "^7.24.6",
-                "@babel/plugin-syntax-jsx": "^7.24.6",
-                "@babel/plugin-transform-modules-commonjs": "^7.24.6",
-                "@babel/plugin-transform-typescript": "^7.24.6"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-validator-option": "^7.24.7",
+                "@babel/plugin-syntax-jsx": "^7.24.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+                "@babel/plugin-transform-typescript": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4066,18 +3985,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.6.tgz",
-            "integrity": "sha512-OsNjaJwT9Zn8ozxcfoBc+RaHdj3gFmCmYoQLUII1o6ZrUwku0BMg80FoOTPx+Gi6XhcQxAYE4xyjPTo4SxEQqw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+            "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
             "dependencies": {
-                "@babel/code-frame": "^7.24.6",
-                "@babel/generator": "^7.24.6",
-                "@babel/helper-environment-visitor": "^7.24.6",
-                "@babel/helper-function-name": "^7.24.6",
-                "@babel/helper-hoist-variables": "^7.24.6",
-                "@babel/helper-split-export-declaration": "^7.24.6",
-                "@babel/parser": "^7.24.6",
-                "@babel/types": "^7.24.6",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-hoist-variables": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -4086,11 +4005,11 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/generator": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.6.tgz",
-            "integrity": "sha512-S7m4eNa6YAPJRHmKsLHIDJhNAGNKoWNiWefz1MBbpnt8g9lvMDl1hir4P9bo/57bQEmuwEhnRU/AMWsD0G/Fbg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
             "dependencies": {
-                "@babel/types": "^7.24.6",
+                "@babel/types": "^7.24.7",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
@@ -4100,11 +4019,11 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.6.tgz",
-            "integrity": "sha512-CvLSkwXGWnYlF9+J3iZUvwgAxKiYzK3BWuo+mLzD/MDGOZDj7Gq8+hqaOkMxmJwmlv0iu86uH5fdADd9Hxkymw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "dependencies": {
-                "@babel/types": "^7.24.6"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4124,12 +4043,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.6.tgz",
-            "integrity": "sha512-WaMsgi6Q8zMgMth93GvWPXkhAIEobfsIkLTacoVZoK1J0CevIPGYY2Vo5YvJGqyHqXM6P4ppOYGsIRU8MM9pFQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.6",
-                "@babel/helper-validator-identifier": "^7.24.6",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -4639,9 +4558,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-cpp": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.8.tgz",
-            "integrity": "sha512-X5uq0uRqN6cyOZOZV1YKi6g8sBtd0+VoF5NbDWURahGR8TRsiztH0sNqs0IB3X0dW4GakU+n9SXcuEmxynkSsw==",
+            "version": "5.1.10",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.1.10.tgz",
+            "integrity": "sha512-BmIF0sAz2BgGEOwzYIeEm9ALneDjd1tcTbFbo+A1Hcq3zOKP8yViSgxS9CEN30KOZIyph6Tldp531UPEpoEl0Q==",
             "dev": true,
             "peer": true
         },
@@ -4674,9 +4593,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-data-science": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-1.0.11.tgz",
-            "integrity": "sha512-TaHAZRVe0Zlcc3C23StZqqbzC0NrodRwoSAc8dis+5qLeLLnOCtagYQeROQvDlcDg3X/VVEO9Whh4W/z4PAmYQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.1.tgz",
+            "integrity": "sha512-xeutkzK0eBe+LFXOFU2kJeAYO6IuFUc1g7iRLr7HeCmlC4rsdGclwGHh61KmttL3+YHQytYStxaRBdGAXWC8Lw==",
             "dev": true,
             "peer": true
         },
@@ -4709,16 +4628,16 @@
             "peer": true
         },
         "node_modules/@cspell/dict-en_us": {
-            "version": "4.3.21",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.21.tgz",
-            "integrity": "sha512-Bzoo2aS4Pej/MGIFlATpp0wMt9IzVHrhDjdV7FgkAIXbjrOn67ojbTxCgWs8AuCNVfK8lBYGEvs5+ElH1msF8w==",
+            "version": "4.3.22",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.22.tgz",
+            "integrity": "sha512-UegkIQhKkTLGarpYNV5ybW2JHzuxhDMOF9q9TW37iG8YoHp5jeVW3C0p3cH9nHWMwEjPinJFfxBd1LPRxGv5dQ==",
             "dev": true,
             "peer": true
         },
         "node_modules/@cspell/dict-en-common-misspellings": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.1.tgz",
-            "integrity": "sha512-uWaP8UG4uvcPyqaG0FzPKCm5kfmhsiiQ45Fs6b3/AEAqfq7Fj1JW0+S3qRt85FQA9SoU6gUJCz9wkK/Ylh7m5A==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.2.tgz",
+            "integrity": "sha512-LA8BO0RaoJD+ExHzK5mz+t9RQ0HaBPDxgR4JTfG8YKJP5keO+pFMH9ZMZphKPjW46QYUZb6Ta1HIRikBEOZfYw==",
             "dev": true,
             "peer": true
         },
@@ -4807,9 +4726,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-java": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.6.tgz",
-            "integrity": "sha512-kdE4AHHHrixyZ5p6zyms1SLoYpaJarPxrz8Tveo6gddszBVVwIUZ+JkQE1bWNLK740GWzIXdkznpUfw1hP9nXw==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.7.tgz",
+            "integrity": "sha512-ejQ9iJXYIq7R09BScU2y5OUGrSqwcD+J5mHFOKbduuQ5s/Eh/duz45KOzykeMLI6KHPVxhBKpUPBWIsfewECpQ==",
             "dev": true,
             "peer": true
         },
@@ -4877,9 +4796,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-php": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.7.tgz",
-            "integrity": "sha512-SUCOBfRDDFz1E2jnAZIIuy8BNbCc8i+VkiL9g4HH9tTN6Nlww5Uz2pMqYS6rZQkXuubqsbkbPlsRiuseEnTmYA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.8.tgz",
+            "integrity": "sha512-TBw3won4MCBQ2wdu7kvgOCR3dY2Tb+LJHgDUpuquy3WnzGiSDJ4AVelrZdE1xu7mjFJUr4q48aB21YT5uQqPZA==",
             "dev": true,
             "peer": true
         },
@@ -4898,13 +4817,13 @@
             "peer": true
         },
         "node_modules/@cspell/dict-python": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.1.11.tgz",
-            "integrity": "sha512-XG+v3PumfzUW38huSbfT15Vqt3ihNb462ulfXifpQllPok5OWynhszCLCRQjQReV+dgz784ST4ggRxW452/kVg==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.1.tgz",
+            "integrity": "sha512-9X2jRgyM0cxBoFQRo4Zc8oacyWnXi+0/bMI5FGibZNZV4y/o9UoFEr6agjU260/cXHTjIdkX233nN7eb7dtyRg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@cspell/dict-data-science": "^1.0.11"
+                "@cspell/dict-data-science": "^2.0.1"
             }
         },
         "node_modules/@cspell/dict-r": {
@@ -4929,9 +4848,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-rust": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.3.tgz",
-            "integrity": "sha512-8DFCzkFQ+2k3fDaezWc/D+0AyiBBiOGYfSDUfrTNU7wpvUvJ6cRcAUshMI/cn2QW/mmxTspRgVlXsE6GUMz00Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.4.tgz",
+            "integrity": "sha512-v9/LcZknt/Xq7m1jdTWiQEtmkVVKdE1etAfGL2sgcWpZYewEa459HeWndNA0gfzQrpWX9sYay18mt7pqClJEdA==",
             "dev": true,
             "peer": true
         },
@@ -4950,9 +4869,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-software-terms": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.4.1.tgz",
-            "integrity": "sha512-JgNHVdWEUhZKCYBiAjsLojkw8WhvsTXyk/IfFby0Lzbl+/AoJvL/XZqr0pvqfpBjbv7pwtnjahrbGxPRCOV+gA==",
+            "version": "3.4.6",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.4.6.tgz",
+            "integrity": "sha512-Cap+WL4iM9NgwxdVIa93aDEGKGNm1t+DLJTnjoWkGHXxSBPG8Kcbnlss6mTtwLv9/NYPmQsmJi5qHXruuHx2ow==",
             "dev": true,
             "peer": true
         },
@@ -6216,14 +6135,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
             "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "aix"
-            ],
+            "os": ["aix"],
             "engines": {
                 "node": ">=12"
             }
@@ -6232,14 +6147,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
             "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -6248,14 +6159,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
             "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -6264,14 +6171,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
             "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -6280,14 +6183,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
             "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -6296,14 +6195,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
             "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -6312,14 +6207,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
             "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -6328,14 +6219,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
             "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -6344,14 +6231,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
             "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6360,14 +6243,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
             "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6376,14 +6255,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
             "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6392,14 +6267,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
             "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
-            "cpu": [
-                "loong64"
-            ],
+            "cpu": ["loong64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6408,14 +6279,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
             "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
-            "cpu": [
-                "mips64el"
-            ],
+            "cpu": ["mips64el"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6424,14 +6291,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
             "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6440,14 +6303,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
             "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6456,14 +6315,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
             "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6472,14 +6327,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
             "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -6488,14 +6339,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
             "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "netbsd"
-            ],
+            "os": ["netbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -6504,14 +6351,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
             "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "openbsd"
-            ],
+            "os": ["openbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -6520,14 +6363,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
             "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "sunos"
-            ],
+            "os": ["sunos"],
             "engines": {
                 "node": ">=12"
             }
@@ -6536,14 +6375,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
             "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -6552,14 +6387,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
             "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -6568,14 +6399,10 @@
             "version": "0.19.12",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
             "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -6729,6 +6556,7 @@
             "version": "0.11.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
             "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+            "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^2.0.2",
@@ -6778,6 +6606,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+            "deprecated": "Use @eslint/object-schema instead",
             "dev": true
         },
         "node_modules/@hutson/parse-repository-url": {
@@ -8433,9 +8262,9 @@
             }
         },
         "node_modules/@nx/angular/node_modules/piscina": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.5.1.tgz",
-            "integrity": "sha512-DVhySLPfqAW+uRH9dF0bjA2xEWr5ANLAzkYXx5adSLMFnwssSIVJYhg0FlvgYsnT/khILQJ3WkjqbAlBvt+maw==",
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.6.0.tgz",
+            "integrity": "sha512-VofazM7TCa/2cYhbtZQFyxJJIKe1JYZ5JBTxGMOo770CYupdVpHNvMrX+fuL+mACQ10ISWbzXFBmYjZvzELG5w==",
             "dev": true,
             "optionalDependencies": {
                 "nice-napi": "^1.0.2"
@@ -8699,14 +8528,14 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.6.tgz",
-            "integrity": "sha512-NTBA2SioI3OsHeIn6sQmhvXleSl9T70YY/hostQLveWs0ic+qvbA3fa0kwAwQ0OA/XGaAerNZRQGJyRfhbJK4g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.7.tgz",
+            "integrity": "sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-remap-async-to-generator": "^7.24.6"
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-remap-async-to-generator": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -8716,13 +8545,13 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.6.tgz",
-            "integrity": "sha512-W3gQydMb0SY99y/2lV0Okx2xg/8KzmZLQsLaiCmwNRl1kKomz14VurEm+2TossUb+sRvBCnGe+wx8KtIgDtBbQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.7.tgz",
+            "integrity": "sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-imports": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
                 "babel-plugin-polyfill-corejs3": "^0.10.1",
                 "babel-plugin-polyfill-regenerator": "^0.6.1",
@@ -8745,27 +8574,27 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/preset-env": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.6.tgz",
-            "integrity": "sha512-CrxEAvN7VxfjOG8JNF2Y/eMqMJbZPZ185amwGUBp8D9USK90xQmv7dLdFSa+VbD7fdIqcy/Mfv7WtzG8+/qxKg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.24.7.tgz",
+            "integrity": "sha512-1YZNsc+y6cTvWlDHidMBsQZrZfEFjRIo/BZCT906PMdzOyXtSLTgqGdrpcuTDCXyd11Am5uQULtDIcCfnTc8fQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.24.6",
-                "@babel/helper-compilation-targets": "^7.24.6",
-                "@babel/helper-plugin-utils": "^7.24.6",
-                "@babel/helper-validator-option": "^7.24.6",
-                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.6",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.6",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.6",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.6",
+                "@babel/compat-data": "^7.24.7",
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-validator-option": "^7.24.7",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.24.7",
+                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.24.7",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.24.7",
                 "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-class-properties": "^7.12.13",
                 "@babel/plugin-syntax-class-static-block": "^7.14.5",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3",
                 "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-                "@babel/plugin-syntax-import-assertions": "^7.24.6",
-                "@babel/plugin-syntax-import-attributes": "^7.24.6",
+                "@babel/plugin-syntax-import-assertions": "^7.24.7",
+                "@babel/plugin-syntax-import-attributes": "^7.24.7",
                 "@babel/plugin-syntax-import-meta": "^7.10.4",
                 "@babel/plugin-syntax-json-strings": "^7.8.3",
                 "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
@@ -8777,54 +8606,54 @@
                 "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
                 "@babel/plugin-syntax-top-level-await": "^7.14.5",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-                "@babel/plugin-transform-arrow-functions": "^7.24.6",
-                "@babel/plugin-transform-async-generator-functions": "^7.24.6",
-                "@babel/plugin-transform-async-to-generator": "^7.24.6",
-                "@babel/plugin-transform-block-scoped-functions": "^7.24.6",
-                "@babel/plugin-transform-block-scoping": "^7.24.6",
-                "@babel/plugin-transform-class-properties": "^7.24.6",
-                "@babel/plugin-transform-class-static-block": "^7.24.6",
-                "@babel/plugin-transform-classes": "^7.24.6",
-                "@babel/plugin-transform-computed-properties": "^7.24.6",
-                "@babel/plugin-transform-destructuring": "^7.24.6",
-                "@babel/plugin-transform-dotall-regex": "^7.24.6",
-                "@babel/plugin-transform-duplicate-keys": "^7.24.6",
-                "@babel/plugin-transform-dynamic-import": "^7.24.6",
-                "@babel/plugin-transform-exponentiation-operator": "^7.24.6",
-                "@babel/plugin-transform-export-namespace-from": "^7.24.6",
-                "@babel/plugin-transform-for-of": "^7.24.6",
-                "@babel/plugin-transform-function-name": "^7.24.6",
-                "@babel/plugin-transform-json-strings": "^7.24.6",
-                "@babel/plugin-transform-literals": "^7.24.6",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.24.6",
-                "@babel/plugin-transform-member-expression-literals": "^7.24.6",
-                "@babel/plugin-transform-modules-amd": "^7.24.6",
-                "@babel/plugin-transform-modules-commonjs": "^7.24.6",
-                "@babel/plugin-transform-modules-systemjs": "^7.24.6",
-                "@babel/plugin-transform-modules-umd": "^7.24.6",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.6",
-                "@babel/plugin-transform-new-target": "^7.24.6",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.6",
-                "@babel/plugin-transform-numeric-separator": "^7.24.6",
-                "@babel/plugin-transform-object-rest-spread": "^7.24.6",
-                "@babel/plugin-transform-object-super": "^7.24.6",
-                "@babel/plugin-transform-optional-catch-binding": "^7.24.6",
-                "@babel/plugin-transform-optional-chaining": "^7.24.6",
-                "@babel/plugin-transform-parameters": "^7.24.6",
-                "@babel/plugin-transform-private-methods": "^7.24.6",
-                "@babel/plugin-transform-private-property-in-object": "^7.24.6",
-                "@babel/plugin-transform-property-literals": "^7.24.6",
-                "@babel/plugin-transform-regenerator": "^7.24.6",
-                "@babel/plugin-transform-reserved-words": "^7.24.6",
-                "@babel/plugin-transform-shorthand-properties": "^7.24.6",
-                "@babel/plugin-transform-spread": "^7.24.6",
-                "@babel/plugin-transform-sticky-regex": "^7.24.6",
-                "@babel/plugin-transform-template-literals": "^7.24.6",
-                "@babel/plugin-transform-typeof-symbol": "^7.24.6",
-                "@babel/plugin-transform-unicode-escapes": "^7.24.6",
-                "@babel/plugin-transform-unicode-property-regex": "^7.24.6",
-                "@babel/plugin-transform-unicode-regex": "^7.24.6",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.24.6",
+                "@babel/plugin-transform-arrow-functions": "^7.24.7",
+                "@babel/plugin-transform-async-generator-functions": "^7.24.7",
+                "@babel/plugin-transform-async-to-generator": "^7.24.7",
+                "@babel/plugin-transform-block-scoped-functions": "^7.24.7",
+                "@babel/plugin-transform-block-scoping": "^7.24.7",
+                "@babel/plugin-transform-class-properties": "^7.24.7",
+                "@babel/plugin-transform-class-static-block": "^7.24.7",
+                "@babel/plugin-transform-classes": "^7.24.7",
+                "@babel/plugin-transform-computed-properties": "^7.24.7",
+                "@babel/plugin-transform-destructuring": "^7.24.7",
+                "@babel/plugin-transform-dotall-regex": "^7.24.7",
+                "@babel/plugin-transform-duplicate-keys": "^7.24.7",
+                "@babel/plugin-transform-dynamic-import": "^7.24.7",
+                "@babel/plugin-transform-exponentiation-operator": "^7.24.7",
+                "@babel/plugin-transform-export-namespace-from": "^7.24.7",
+                "@babel/plugin-transform-for-of": "^7.24.7",
+                "@babel/plugin-transform-function-name": "^7.24.7",
+                "@babel/plugin-transform-json-strings": "^7.24.7",
+                "@babel/plugin-transform-literals": "^7.24.7",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+                "@babel/plugin-transform-member-expression-literals": "^7.24.7",
+                "@babel/plugin-transform-modules-amd": "^7.24.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+                "@babel/plugin-transform-modules-systemjs": "^7.24.7",
+                "@babel/plugin-transform-modules-umd": "^7.24.7",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+                "@babel/plugin-transform-new-target": "^7.24.7",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+                "@babel/plugin-transform-numeric-separator": "^7.24.7",
+                "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+                "@babel/plugin-transform-object-super": "^7.24.7",
+                "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+                "@babel/plugin-transform-optional-chaining": "^7.24.7",
+                "@babel/plugin-transform-parameters": "^7.24.7",
+                "@babel/plugin-transform-private-methods": "^7.24.7",
+                "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+                "@babel/plugin-transform-property-literals": "^7.24.7",
+                "@babel/plugin-transform-regenerator": "^7.24.7",
+                "@babel/plugin-transform-reserved-words": "^7.24.7",
+                "@babel/plugin-transform-shorthand-properties": "^7.24.7",
+                "@babel/plugin-transform-spread": "^7.24.7",
+                "@babel/plugin-transform-sticky-regex": "^7.24.7",
+                "@babel/plugin-transform-template-literals": "^7.24.7",
+                "@babel/plugin-transform-typeof-symbol": "^7.24.7",
+                "@babel/plugin-transform-unicode-escapes": "^7.24.7",
+                "@babel/plugin-transform-unicode-property-regex": "^7.24.7",
+                "@babel/plugin-transform-unicode-regex": "^7.24.7",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.24.7",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
                 "babel-plugin-polyfill-corejs2": "^0.4.10",
                 "babel-plugin-polyfill-corejs3": "^0.10.4",
@@ -8863,9 +8692,9 @@
             }
         },
         "node_modules/@nx/js/node_modules/@babel/runtime": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz",
-            "integrity": "sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+            "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -9167,14 +8996,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.0.8.tgz",
             "integrity": "sha512-EuK/K6vAh2unCijDjDnIAqDSFIPNStbnbKml+W2JEsTkw36YinKhXbeATYTVXqUGgzMIAGMxylSJawvCYnaFOw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9183,14 +9008,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.0.8.tgz",
             "integrity": "sha512-6Xt2AgL5wG+cfmSTD5YPVchq+MfJSjD1OTOTZSVFLJ+U8H84UrmNwKnEj5wF0roRWeAV7ircnijaFqHHzlB35g==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9199,14 +9020,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.0.8.tgz",
             "integrity": "sha512-ZHDvSbPx2nsA28bYMkRZeMToPsFXliknGxAKmNFgFlEi8cBgn6bs2gg1n7gVokXYMDzv1LeWHx8Wmq9OpkK6xw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9215,14 +9032,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.0.8.tgz",
             "integrity": "sha512-wJ+sBa77zWTeFyVf01DGvw599jhqzVb6AFy6U9mW6tfERKhcQ4DzvqgyUM1OeNs+txyIi0eDJJOCLBA0oXw/2A==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9231,14 +9044,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.0.8.tgz",
             "integrity": "sha512-OT14ka2M4gplHSKuQiNwe5Vynt5P0Y2rXvjcCdD4he2oT7QncrwGBMt4vE0NU4+oXVErfRZLpzXipMSo6Iq8Xw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9247,14 +9056,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.0.8.tgz",
             "integrity": "sha512-HezQsHSvK7+XXjvtWEx+G2d/9oxLKWCXobWEaEOFBwWn7dXDTTp64A5IZyyztZMzRT1ESJfrjVI2V9NUnZB31A==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9263,14 +9068,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.0.8.tgz",
             "integrity": "sha512-mJkk7dQhjfmdl0hHFJRSFNNAqpy/uvnyIn8SRyI8HDHABAqmNVfA31EYUI+2SR27U/agHzBG9BIFqP9qLTUalw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9279,14 +9080,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.0.8.tgz",
             "integrity": "sha512-yhj3/Q8/4VQCSkQVQc68LNPjRpqXML0FKxiBEuziPAaCO9TipAalwH5DJrcLgNUdZkk0LNNAGmhbQBmUnh2ZXw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9295,14 +9092,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.0.8.tgz",
             "integrity": "sha512-B0aBWdAzF8GFz7z5xy0jXCWNmaiapa6IYcfhlR+3F+LIGWNnDmZddmqMVh2uQakGWCBTN7CjKkWQn8ise5fLzA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -9311,14 +9104,10 @@
             "version": "19.0.8",
             "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.0.8.tgz",
             "integrity": "sha512-2f1KtC5fXHrI6HnvPZUIHyw4gjCQFm/Sd05CeSRbvWTAtgFRqrBn0olCCx76MDHxMjddnzzlwkAsC8WD2U6M8g==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -10235,209 +10024,145 @@
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
             "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ]
+            "os": ["android"]
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
             "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ]
+            "os": ["android"]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
             "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ]
+            "os": ["darwin"]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
             "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ]
+            "os": ["darwin"]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
             "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
             "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
             "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
             "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
             "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
             "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
             "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
             "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
             "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
             "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
             "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.18.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
             "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@samverschueren/stream-to-observable": {
             "version": "0.3.1",
@@ -11183,9 +10908,9 @@
             }
         },
         "node_modules/@taiga-ui/i18n": {
-            "version": "3.82.0",
-            "resolved": "https://registry.npmjs.org/@taiga-ui/i18n/-/i18n-3.82.0.tgz",
-            "integrity": "sha512-GXffvass6w/SLxVggH2jXv2FeHTMcGs0aAZdKFYC8EetiHN04cPlki3W+PiYM/kYMonI9vIN41l0lgXUqPMUMA==",
+            "version": "3.84.0",
+            "resolved": "https://registry.npmjs.org/@taiga-ui/i18n/-/i18n-3.84.0.tgz",
+            "integrity": "sha512-G7MBAwUSYFli0GxidZTlDTBOxKMlSyOWIDHCUaQ+xl4LshAbenHz71jVudQT+9Ph88Hg9Ia46BBC1vMpcJlPJA==",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -11910,9 +11635,7 @@
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "engines": [
-                "node >= 0.8"
-            ],
+            "engines": ["node >= 0.8"],
             "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
@@ -13775,9 +13498,9 @@
             }
         },
         "node_modules/@taiga-ui/testing/node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "peer": true,
             "engines": {
                 "node": ">=8.3.0"
@@ -14938,7 +14661,6 @@
             "version": "20.14.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.5.tgz",
             "integrity": "sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==",
-            "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -15144,17 +14866,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.12.0.tgz",
-            "integrity": "sha512-7F91fcbuDf/d3S8o21+r3ZncGIke/+eWk0EpO21LXhDfLahriZF9CGj4fbAetEjlaBdjdSm9a6VeXbpbT6Z40Q==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.1.tgz",
+            "integrity": "sha512-kZqi+WZQaZfPKnsflLJQCz6Ze9FFSMfXrrIOcyargekQxG37ES7DJNpJUE9Q/X5n3yTIP/WPutVNzgknQ7biLg==",
             "dev": true,
             "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "7.12.0",
-                "@typescript-eslint/type-utils": "7.12.0",
-                "@typescript-eslint/utils": "7.12.0",
-                "@typescript-eslint/visitor-keys": "7.12.0",
+                "@typescript-eslint/scope-manager": "7.13.1",
+                "@typescript-eslint/type-utils": "7.13.1",
+                "@typescript-eslint/utils": "7.13.1",
+                "@typescript-eslint/visitor-keys": "7.13.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -15340,16 +15062,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.12.0.tgz",
-            "integrity": "sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.1.tgz",
+            "integrity": "sha512-1ELDPlnLvDQ5ybTSrMhRTFDfOQEOXNM+eP+3HT/Yq7ruWpciQw+Avi73pdEbA4SooCawEWo3dtYbF68gN7Ed1A==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "7.12.0",
-                "@typescript-eslint/types": "7.12.0",
-                "@typescript-eslint/typescript-estree": "7.12.0",
-                "@typescript-eslint/visitor-keys": "7.12.0",
+                "@typescript-eslint/scope-manager": "7.13.1",
+                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/typescript-estree": "7.13.1",
+                "@typescript-eslint/visitor-keys": "7.13.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -15369,13 +15091,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.12.0.tgz",
-            "integrity": "sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.1.tgz",
+            "integrity": "sha512-adbXNVEs6GmbzaCpymHQ0MB6E4TqoiVbC0iqG3uijR8ZYfpAXMGttouQzF4Oat3P2GxDVIrg7bMI/P65LiQZdg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.12.0",
-                "@typescript-eslint/visitor-keys": "7.12.0"
+                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/visitor-keys": "7.13.1"
             },
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -15386,13 +15108,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.12.0.tgz",
-            "integrity": "sha512-lib96tyRtMhLxwauDWUp/uW3FMhLA6D0rJ8T7HmH7x23Gk1Gwwu8UZ94NMXBvOELn6flSPiBrCKlehkiXyaqwA==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.1.tgz",
+            "integrity": "sha512-aWDbLu1s9bmgPGXSzNCxELu+0+HQOapV/y+60gPXafR8e2g1Bifxzevaa+4L2ytCWm+CHqpELq4CSoN9ELiwCg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "7.12.0",
-                "@typescript-eslint/utils": "7.12.0",
+                "@typescript-eslint/typescript-estree": "7.13.1",
+                "@typescript-eslint/utils": "7.13.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -15413,9 +15135,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.12.0.tgz",
-            "integrity": "sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.1.tgz",
+            "integrity": "sha512-7K7HMcSQIAND6RBL4kDl24sG/xKM13cA85dc7JnmQXw2cBDngg7c19B++JzvJHRG3zG36n9j1i451GBzRuHchw==",
             "dev": true,
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -15426,13 +15148,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.12.0.tgz",
-            "integrity": "sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.1.tgz",
+            "integrity": "sha512-uxNr51CMV7npU1BxZzYjoVz9iyjckBduFBP0S5sLlh1tXYzHzgZ3BR9SVsNed+LmwKrmnqN3Kdl5t7eZ5TS1Yw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.12.0",
-                "@typescript-eslint/visitor-keys": "7.12.0",
+                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/visitor-keys": "7.13.1",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -15481,15 +15203,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.12.0.tgz",
-            "integrity": "sha512-Y6hhwxwDx41HNpjuYswYp6gDbkiZ8Hin9Bf5aJQn1bpTs3afYY4GX+MPYxma8jtoIV2GRwTM/UJm/2uGCVv+DQ==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.1.tgz",
+            "integrity": "sha512-h5MzFBD5a/Gh/fvNdp9pTfqJAbuQC4sCN2WzuXme71lqFJsZtLbjxfSk4r3p02WIArOF9N94pdsLiGutpDbrXQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "7.12.0",
-                "@typescript-eslint/types": "7.12.0",
-                "@typescript-eslint/typescript-estree": "7.12.0"
+                "@typescript-eslint/scope-manager": "7.13.1",
+                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/typescript-estree": "7.13.1"
             },
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -15503,12 +15225,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.12.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.12.0.tgz",
-            "integrity": "sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==",
+            "version": "7.13.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.1.tgz",
+            "integrity": "sha512-k/Bfne7lrP7hcb7m9zSsgcBmo+8eicqqfNAJ7uUY+jkTFpKeH2FSkWpFRtimBxgkyvqfu9jTPRbYOvud6isdXA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.12.0",
+                "@typescript-eslint/types": "7.13.1",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -16171,9 +15893,9 @@
             }
         },
         "node_modules/@wessberg/ts-evaluator/node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "dev": true,
             "engines": {
                 "node": ">=8.3.0"
@@ -16314,9 +16036,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+            "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -16352,9 +16074,12 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-            "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+            "version": "8.3.3",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+            "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -16510,9 +16235,7 @@
             "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
             "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
             "dev": true,
-            "engines": [
-                "node >= 0.8.0"
-            ],
+            "engines": ["node >= 0.8.0"],
             "bin": {
                 "ansi-html": "bin/ansi-html"
             }
@@ -18251,9 +17974,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001628",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001628.tgz",
-            "integrity": "sha512-S3BnR4Kh26TBxbi5t5kpbcUlLJb9lhtDXISDPwOfI+JoC+ik0QksvkZtUVyikw3hjnkgkMPSJ8oIM9yMm9vflA==",
+            "version": "1.0.30001636",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
+            "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -18869,9 +18592,7 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
             "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
             "dev": true,
-            "engines": [
-                "node >= 6.0"
-            ],
+            "engines": ["node >= 6.0"],
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -20147,9 +19868,9 @@
             }
         },
         "node_modules/core-js-compat/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -20166,10 +19887,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -21011,9 +20732,9 @@
             }
         },
         "node_modules/cssnano-preset-default/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -21030,10 +20751,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -22848,9 +22569,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.790",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.790.tgz",
-            "integrity": "sha512-eVGeQxpaBYbomDBa/Mehrs28MdvCXfJmEFzaMFsv8jH/MJDLIylJN81eTJ5kvx7B7p18OiPK0BkC06lydEy63A=="
+            "version": "1.4.805",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.805.tgz",
+            "integrity": "sha512-8W4UJwX/w9T0QSzINJckTKG6CYpAUTqsaWcWIsdud3I1FYJcMgW9QqT1/4CBff/pP/TihWh13OmiyY8neto6vw=="
         },
         "node_modules/elegant-spinner": {
             "version": "1.0.1",
@@ -22947,9 +22668,9 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
-            "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+            "version": "6.5.5",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+            "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
             "dev": true,
             "dependencies": {
                 "@types/cookie": "^0.4.1",
@@ -22961,44 +22682,23 @@
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.2.1",
-                "ws": "~8.11.0"
+                "ws": "~8.17.1"
             },
             "engines": {
                 "node": ">=10.2.0"
             }
         },
         "node_modules/engine.io-client": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-            "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+            "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
             "dev": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.2.1",
-                "ws": "~8.11.0",
+                "ws": "~8.17.1",
                 "xmlhttprequest-ssl": "~2.0.0"
-            }
-        },
-        "node_modules/engine.io-client/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/engine.io-parser": {
@@ -23017,27 +22717,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/engine.io/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/enhanced-resolve": {
@@ -23990,9 +23669,9 @@
             }
         },
         "node_modules/eslint-plugin-jest": {
-            "version": "28.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.5.0.tgz",
-            "integrity": "sha512-6np6DGdmNq/eBbA7HOUNV8fkfL86PYwBfwyb8n23FXgJNTR8+ot3smRHjza9LGsBBZRypK3qyF79vMjohIL8eQ==",
+            "version": "28.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.6.0.tgz",
+            "integrity": "sha512-YG28E1/MIKwnz+e2H7VwYPzHUYU4aMa19w0yGcwXnnmJH6EfgHahTJ2un3IyraUxNfnz/KUhJAFXNNwWPo12tg==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -24046,9 +23725,9 @@
             }
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/@babel/runtime": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz",
-            "integrity": "sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+            "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -24108,9 +23787,9 @@
             }
         },
         "node_modules/eslint-plugin-perfectionist": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.10.0.tgz",
-            "integrity": "sha512-P+tdrkHeMWBc55+DZsoDOAftV1WCsEoHaKm6JC7zajFus/syfT4vUPBFb3atGFSuyaVnGQGHlcKpP9X3Q0gH/w==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.11.0.tgz",
+            "integrity": "sha512-XrtBtiu5rbQv88gl+1e2RQud9te9luYNvKIgM9emttQ2zutHPzY/AQUucwxscDKV4qlTkvLTxjOFvxqeDpPorw==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -24119,10 +23798,10 @@
                 "natural-compare-lite": "^1.4.0"
             },
             "peerDependencies": {
-                "astro-eslint-parser": "^0.16.0",
+                "astro-eslint-parser": "^1.0.2",
                 "eslint": ">=8.0.0",
                 "svelte": ">=3.0.0",
-                "svelte-eslint-parser": "^0.33.0",
+                "svelte-eslint-parser": "^0.37.0",
                 "vue-eslint-parser": ">=9.0.0"
             },
             "peerDependenciesMeta": {
@@ -24498,13 +24177,13 @@
             }
         },
         "node_modules/eslint-plugin-unicorn/node_modules/espree": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
-            "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+            "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "acorn": "^8.11.3",
+                "acorn": "^8.12.0",
                 "acorn-jsx": "^5.3.2",
                 "eslint-visitor-keys": "^4.0.0"
             },
@@ -25472,9 +25151,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-            "engines": [
-                "node >=0.6.0"
-            ]
+            "engines": ["node >=0.6.0"]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -25891,9 +25568,9 @@
             }
         },
         "node_modules/foreground-child": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+            "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
             "dev": true,
             "dependencies": {
                 "cross-spawn": "^7.0.0",
@@ -26240,9 +25917,7 @@
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "hasInstallScript": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -28907,9 +28582,9 @@
             }
         },
         "node_modules/jackspeak": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.3.0.tgz",
-            "integrity": "sha512-glPiBfKguqA7v8JsXO3iLjJWZ9FV1vNpoI0I9hI9Mnk5yetO9uPLSpiCEmiVijAssv2f54HpvtzvAHfhPieiDQ==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+            "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
             "dev": true,
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
@@ -31201,9 +30876,9 @@
             }
         },
         "node_modules/jest-jasmine2/node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "peer": true,
             "engines": {
                 "node": ">=8.3.0"
@@ -32535,9 +32210,9 @@
             }
         },
         "node_modules/jiti": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.1.tgz",
-            "integrity": "sha512-KMXpzEJMsOFyRj6ZpDTnnlJrdr9umUY+eut5vlRvjVixohitnRFIRTFw9MEu9zPlBxTHZo6xD5ftKYiQZuJYQw==",
+            "version": "1.21.6",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+            "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
             "dev": true,
             "peer": true,
             "bin": {
@@ -32784,9 +32459,7 @@
             "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
             "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
             "dev": true,
-            "engines": [
-                "node >= 0.2.0"
-            ]
+            "engines": ["node >= 0.2.0"]
         },
         "node_modules/JSONStream": {
             "version": "1.3.5",
@@ -32808,9 +32481,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
             "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
-            "engines": [
-                "node >=0.6.0"
-            ],
+            "engines": ["node >=0.6.0"],
             "dependencies": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -32846,10 +32517,7 @@
             "version": "0.16.10",
             "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.10.tgz",
             "integrity": "sha512-ZiqaC04tp2O5utMsl2TEZTXxa6WSC4yo0fv5ML++D3QZv/vx2Mct0mTlRx3O+uUkjfuAgOkzsCmq5MiUEsDDdA==",
-            "funding": [
-                "https://opencollective.com/katex",
-                "https://github.com/sponsors/katex"
-            ],
+            "funding": ["https://opencollective.com/katex", "https://github.com/sponsors/katex"],
             "optional": true,
             "dependencies": {
                 "commander": "^8.3.0"
@@ -33060,8 +32728,7 @@
             "version": "1.11.3",
             "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.3.tgz",
             "integrity": "sha512-RU0CTsLCu2v6VEzdP+W6UU2n5+jEpMDRkGxUeBgsAJgre3vKgm17eApISH9OQY4G0jZYJVIc8qXmz6CJFueAFg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/license-webpack-plugin": {
             "version": "4.0.2",
@@ -33081,9 +32748,9 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
-            "integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+            "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -34729,10 +34396,7 @@
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
             "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
+            "funding": ["https://github.com/sponsors/broofa", "https://github.com/sponsors/ctavan"],
             "optional": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
@@ -35408,14 +35072,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
             "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -35424,14 +35084,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
             "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -35440,14 +35096,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
             "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=12"
             }
@@ -35456,14 +35108,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
             "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -35472,14 +35120,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
             "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=12"
             }
@@ -35488,14 +35132,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
             "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -35504,14 +35144,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
             "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -35520,14 +35156,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
             "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35536,14 +35168,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
             "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35552,14 +35180,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
             "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35568,14 +35192,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
             "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-            "cpu": [
-                "loong64"
-            ],
+            "cpu": ["loong64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35584,14 +35204,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
             "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-            "cpu": [
-                "mips64el"
-            ],
+            "cpu": ["mips64el"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35600,14 +35216,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
             "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35616,14 +35228,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
             "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35632,14 +35240,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
             "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35648,14 +35252,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
             "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=12"
             }
@@ -35664,14 +35264,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
             "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "netbsd"
-            ],
+            "os": ["netbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -35680,14 +35276,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
             "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "openbsd"
-            ],
+            "os": ["openbsd"],
             "engines": {
                 "node": ">=12"
             }
@@ -35696,14 +35288,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
             "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "sunos"
-            ],
+            "os": ["sunos"],
             "engines": {
                 "node": ">=12"
             }
@@ -35712,14 +35300,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
             "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -35728,14 +35312,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
             "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -35744,14 +35324,10 @@
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
             "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=12"
             }
@@ -35871,9 +35447,7 @@
             "dev": true,
             "hasInstallScript": true,
             "optional": true,
-            "os": [
-                "!win32"
-            ],
+            "os": ["!win32"],
             "dependencies": {
                 "node-addon-api": "^3.0.0",
                 "node-gyp-build": "^4.2.2"
@@ -37797,9 +37371,9 @@
             }
         },
         "node_modules/postcss-colormin/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -37816,10 +37390,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -37845,9 +37419,9 @@
             }
         },
         "node_modules/postcss-convert-values/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -37864,10 +37438,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -38381,9 +37955,9 @@
             }
         },
         "node_modules/postcss-merge-rules/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -38400,10 +37974,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -38462,9 +38036,9 @@
             }
         },
         "node_modules/postcss-minify-params/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -38481,10 +38055,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -38717,9 +38291,9 @@
             }
         },
         "node_modules/postcss-normalize-unicode/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -38736,10 +38310,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -38997,9 +38571,9 @@
             }
         },
         "node_modules/postcss-preset-env/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -39016,10 +38590,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -39070,9 +38644,9 @@
             }
         },
         "node_modules/postcss-reduce-initial/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -39089,10 +38663,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -39308,7 +38882,6 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
             "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -39673,6 +39246,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+            "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
             "dev": true,
             "engines": {
                 "node": ">=0.6.0",
@@ -40559,9 +40133,9 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-            "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true
         },
         "node_modules/rimraf": {
@@ -43000,34 +42574,13 @@
             }
         },
         "node_modules/socket.io-adapter": {
-            "version": "2.5.4",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
-            "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+            "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
             "dev": true,
             "dependencies": {
                 "debug": "~4.3.4",
-                "ws": "~8.11.0"
-            }
-        },
-        "node_modules/socket.io-adapter/node_modules/ws": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
+                "ws": "~8.17.1"
             }
         },
         "node_modules/socket.io-client": {
@@ -43988,9 +43541,9 @@
             }
         },
         "node_modules/stylehacks/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -44007,10 +43560,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -44923,9 +44476,9 @@
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/terser": {
-            "version": "5.31.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
-            "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+            "version": "5.31.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
+            "integrity": "sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -45866,9 +45419,9 @@
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
         },
         "node_modules/uglify-js": {
-            "version": "3.17.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "version": "3.18.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+            "integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -46267,9 +45820,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "engines": [
-                "node >=0.6.0"
-            ],
+            "engines": ["node >=0.6.0"],
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
@@ -46316,9 +45867,9 @@
             }
         },
         "node_modules/vue-component-type-helpers": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.0.19.tgz",
-            "integrity": "sha512-cN3f1aTxxKo4lzNeQAkVopswuImUrb5Iurll9Gaw5cqpnbTAxtEMM1mgi6ou4X79OCyqYv1U1mzBHJkzmiK82w==",
+            "version": "2.0.21",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.0.21.tgz",
+            "integrity": "sha512-3NaicyZ7N4B6cft4bfb7dOnPbE9CjLcx+6wZWAg5zwszfO4qXRh+U52dN5r5ZZfc6iMaxKCEcoH9CmxxoFZHLg==",
             "dev": true
         },
         "node_modules/w3c-hr-time": {
@@ -46639,9 +46190,9 @@
             }
         },
         "node_modules/webpack/node_modules/browserslist": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -46658,10 +46209,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -47037,9 +46588,9 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-            "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -47140,9 +46691,9 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         },
         "node_modules/yaml": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.3.tgz",
-            "integrity": "sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+            "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
             "dev": true,
             "bin": {
                 "yaml": "bin.mjs"
@@ -47259,6 +46810,7 @@
                 "@maskito/angular": "*",
                 "@maskito/core": "*",
                 "@maskito/kit": "*",
+                "@ng-web-apis/common": "3.0.6",
                 "@ng-web-apis/universal": "3.0.7",
                 "@nguniversal/express-engine": "15.2.1",
                 "@stackblitz/sdk": "1.10.0",

--- a/projects/demo/package.json
+++ b/projects/demo/package.json
@@ -14,6 +14,7 @@
         "@maskito/angular": "*",
         "@maskito/core": "*",
         "@maskito/kit": "*",
+        "@ng-web-apis/common": "3.0.6",
         "@ng-web-apis/universal": "3.0.7",
         "@nguniversal/express-engine": "15.2.1",
         "@stackblitz/sdk": "1.10.0",


### PR DESCRIPTION
```shell
Command failed: npm i --workspaces --include-workspace-root
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: @maskito/demo@undefined
npm error Found: @angular/common@15.2.10
npm error node_modules/@angular/common
npm error   @angular/common@"15.2.10" from @maskito/demo@undefined
npm error   projects/demo
npm error     @maskito/demo@undefined
npm error     node_modules/@maskito/demo
npm error       workspace projects/demo from the root project
npm error
npm error Could not resolve dependency:
npm error peer @angular/common@">=16.0.0" from @ng-web-apis/common@4.0.0
npm error node_modules/@ng-web-apis/common
npm error   peer @ng-web-apis/common@">=2.0.0" from @ng-web-apis/universal@3.0.7
npm error   node_modules/@ng-web-apis/universal
npm error     @ng-web-apis/universal@"3.0.7" from @maskito/demo@undefined
npm error     projects/demo
npm error       @maskito/demo@undefined
npm error       node_modules/@maskito/demo
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```