### PR TITLE
feat(phone)!: remove built-in `RemoveOnBlur` / `AddOnFocus` plugins from `@maskito/phone`

### DIFF
--- a/projects/demo/src/pages/phone/examples/5-focus-blur-events/component.ts
+++ b/projects/demo/src/pages/phone/examples/5-focus-blur-events/component.ts
@@ -1,0 +1,50 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MaskitoDirective} from '@maskito/angular';
+import {TuiFlagPipeModule, TuiTextfieldControllerModule} from '@taiga-ui/core';
+import {TuiInputModule} from '@taiga-ui/kit';
+
+import mask from './mask';
+
+@Component({
+    standalone: true,
+    selector: 'phone-doc-example-5',
+    imports: [
+        TuiInputModule,
+        TuiTextfieldControllerModule,
+        FormsModule,
+        MaskitoDirective,
+        TuiFlagPipeModule,
+    ],
+    template: `
+        <tui-input
+            #textfield
+            [style.max-width.rem]="30"
+            [tuiTextfieldCustomContent]="flag"
+            [(ngModel)]="value"
+        >
+            {{
+                textfield.focused ? 'Blur me to remove prefix' : 'Focus me to see prefix'
+            }}
+            <input
+                autocomplete="tel"
+                inputmode="tel"
+                tuiTextfield
+                [maskito]="mask"
+            />
+
+            <ng-template #flag>
+                <img
+                    alt="Turkish flag"
+                    width="28"
+                    [src]="'TR' | tuiFlag"
+                />
+            </ng-template>
+        </tui-input>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PhoneMaskDocExample5 {
+    protected value = '';
+    protected readonly mask = mask;
+}

--- a/projects/demo/src/pages/phone/examples/5-focus-blur-events/mask.ts
+++ b/projects/demo/src/pages/phone/examples/5-focus-blur-events/mask.ts
@@ -1,0 +1,24 @@
+import type {MaskitoOptions} from '@maskito/core';
+import {maskitoAddOnFocusPlugin, maskitoRemoveOnBlurPlugin} from '@maskito/kit';
+import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {getCountryCallingCode} from 'libphonenumber-js/core';
+import metadata from 'libphonenumber-js/min/metadata';
+
+const countryIsoCode = 'TR';
+const code = getCountryCallingCode(countryIsoCode, metadata);
+const prefix = `+${code} `;
+
+const phoneOptions = maskitoPhoneOptionsGenerator({
+    metadata,
+    countryIsoCode,
+    strict: true,
+});
+
+export default {
+    ...phoneOptions,
+    plugins: [
+        ...phoneOptions.plugins,
+        maskitoAddOnFocusPlugin(prefix),
+        maskitoRemoveOnBlurPlugin(prefix),
+    ],
+} as MaskitoOptions;

--- a/projects/demo/src/pages/phone/phone-doc.template.html
+++ b/projects/demo/src/pages/phone/phone-doc.template.html
@@ -113,6 +113,23 @@
                 </p>
             </ng-template>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="focus-blur"
+            heading="Focus & Blur events"
+            [content]="focusBlurEvents"
+            [description]="focusBlurEventDescription"
+        >
+            <phone-doc-example-5 />
+
+            <ng-template #focusBlurEventDescription>
+                Use
+                <code>maskitoAddOnFocusPlugin</code>
+                /
+                <code>maskitoRemoveOnBlurPlugin</code>
+                to mutate textfield's value on focus/blur events.
+            </ng-template>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>

--- a/projects/phone/src/lib/masks/phone/phone-mask-strict.ts
+++ b/projects/phone/src/lib/masks/phone/phone-mask-strict.ts
@@ -1,11 +1,6 @@
 import type {MaskitoOptions} from '@maskito/core';
 import {MASKITO_DEFAULT_OPTIONS} from '@maskito/core';
-import {
-    maskitoAddOnFocusPlugin,
-    maskitoCaretGuard,
-    maskitoPrefixPostprocessorGenerator,
-    maskitoRemoveOnBlurPlugin,
-} from '@maskito/kit';
+import {maskitoCaretGuard, maskitoPrefixPostprocessorGenerator} from '@maskito/kit';
 import type {CountryCode, MetadataJson} from 'libphonenumber-js/core';
 import {AsYouType, getCountryCallingCode} from 'libphonenumber-js/core';
 
@@ -53,10 +48,6 @@ export function maskitoPhoneStrictOptionsGenerator({
                 from === to ? prefix.length : 0,
                 value.length,
             ]),
-            // TODO: drop `maskitoAddOnFocusPlugin` & `maskitoRemoveOnBlurPlugin`
-            // TODO: Add examples how to enable `maskitoAddOnFocusPlugin` & `maskitoRemoveOnBlurPlugin` on https://maskito.dev/addons/phone
-            maskitoRemoveOnBlurPlugin(prefix),
-            maskitoAddOnFocusPlugin(prefix),
         ],
         postprocessors: [
             maskitoPrefixPostprocessorGenerator(prefix),


### PR DESCRIPTION
Closes #1134


Relates to these lines from Taiga UI:
https://github.com/taiga-family/taiga-ui/blob/8da2d665467b1d61e277f5574a09646b81e7ca99/projects/kit/components/input-phone-international/input-phone-international.component.ts#L188-L199
