### PR TITLE
fix(kit): `maskitoStringifyTime` was adding `0` on the wrong side

### DIFF
--- a/projects/demo/src/pages/kit/time/time-mask-doc.component.ts
+++ b/projects/demo/src/pages/kit/time/time-mask-doc.component.ts
@@ -66,7 +66,11 @@ export default class TimeMaskDocComponent implements GeneratorOptions {
 
     protected readonly timeSegmentMaxValuesOptions: Array<
         Partial<MaskitoTimeSegments<number>>
-    > = [{hours: 23, minutes: 59, seconds: 59, milliseconds: 999}, {hours: 11}];
+    > = [
+        {hours: 23, minutes: 59, seconds: 59, milliseconds: 999},
+        {hours: 11},
+        {hours: 9, minutes: 9, seconds: 9, milliseconds: 9},
+    ];
 
     public mode: MaskitoTimeMode = this.modeOptions[0];
     public timeSegmentMaxValues: Partial<MaskitoTimeSegments<number>> =

--- a/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
+++ b/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
@@ -3,7 +3,7 @@ import type {MaskitoPreprocessor} from '@maskito/core';
 import {DEFAULT_TIME_SEGMENT_MAX_VALUES, TIME_FIXED_CHARACTERS} from '../../../constants';
 import type {MaskitoTimeMode} from '../../../types';
 import {escapeRegExp, validateDateString} from '../../../utils';
-import {padTimeSegments, validateTimeString} from '../../../utils/time';
+import {padEndTimeSegments, validateTimeString} from '../../../utils/time';
 import {parseDateTimeString} from '../utils';
 
 export function createValidDateTimePreprocessor({
@@ -66,7 +66,7 @@ export function createValidDateTimePreprocessor({
 
         validatedValue += validatedDateString;
 
-        const paddedMaxValues = padTimeSegments(DEFAULT_TIME_SEGMENT_MAX_VALUES);
+        const paddedMaxValues = padEndTimeSegments(DEFAULT_TIME_SEGMENT_MAX_VALUES);
 
         const {validatedTimeString, updatedTimeSelection} = validateTimeString({
             timeString,

--- a/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
+++ b/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
@@ -3,7 +3,7 @@ import type {MaskitoPreprocessor} from '@maskito/core';
 import {DEFAULT_TIME_SEGMENT_MAX_VALUES, TIME_FIXED_CHARACTERS} from '../../../constants';
 import type {MaskitoTimeMode} from '../../../types';
 import {escapeRegExp, validateDateString} from '../../../utils';
-import {padEndTimeSegments, validateTimeString} from '../../../utils/time';
+import {padStartTimeSegments, validateTimeString} from '../../../utils/time';
 import {parseDateTimeString} from '../utils';
 
 export function createValidDateTimePreprocessor({
@@ -66,7 +66,7 @@ export function createValidDateTimePreprocessor({
 
         validatedValue += validatedDateString;
 
-        const paddedMaxValues = padEndTimeSegments(DEFAULT_TIME_SEGMENT_MAX_VALUES);
+        const paddedMaxValues = padStartTimeSegments(DEFAULT_TIME_SEGMENT_MAX_VALUES);
 
         const {validatedTimeString, updatedTimeSelection} = validateTimeString({
             timeString,

--- a/projects/kit/src/lib/masks/time/processors/max-validation-preprocessor.ts
+++ b/projects/kit/src/lib/masks/time/processors/max-validation-preprocessor.ts
@@ -3,13 +3,13 @@ import type {MaskitoPreprocessor} from '@maskito/core';
 import {TIME_FIXED_CHARACTERS} from '../../../constants';
 import type {MaskitoTimeMode, MaskitoTimeSegments} from '../../../types';
 import {escapeRegExp} from '../../../utils';
-import {padTimeSegments, validateTimeString} from '../../../utils/time';
+import {padEndTimeSegments, validateTimeString} from '../../../utils/time';
 
 export function createMaxValidationPreprocessor(
     timeSegmentMaxValues: MaskitoTimeSegments<number>,
     timeMode: MaskitoTimeMode,
 ): MaskitoPreprocessor {
-    const paddedMaxValues = padTimeSegments(timeSegmentMaxValues);
+    const paddedMaxValues = padEndTimeSegments(timeSegmentMaxValues);
     const invalidCharsRegExp = new RegExp(
         `[^\\d${TIME_FIXED_CHARACTERS.map(escapeRegExp).join('')}]+`,
     );

--- a/projects/kit/src/lib/masks/time/processors/max-validation-preprocessor.ts
+++ b/projects/kit/src/lib/masks/time/processors/max-validation-preprocessor.ts
@@ -3,13 +3,13 @@ import type {MaskitoPreprocessor} from '@maskito/core';
 import {TIME_FIXED_CHARACTERS} from '../../../constants';
 import type {MaskitoTimeMode, MaskitoTimeSegments} from '../../../types';
 import {escapeRegExp} from '../../../utils';
-import {padEndTimeSegments, validateTimeString} from '../../../utils/time';
+import {padStartTimeSegments, validateTimeString} from '../../../utils/time';
 
 export function createMaxValidationPreprocessor(
     timeSegmentMaxValues: MaskitoTimeSegments<number>,
     timeMode: MaskitoTimeMode,
 ): MaskitoPreprocessor {
-    const paddedMaxValues = padEndTimeSegments(timeSegmentMaxValues);
+    const paddedMaxValues = padStartTimeSegments(timeSegmentMaxValues);
     const invalidCharsRegExp = new RegExp(
         `[^\\d${TIME_FIXED_CHARACTERS.map(escapeRegExp).join('')}]+`,
     );

--- a/projects/kit/src/lib/masks/time/utils/parse-time.ts
+++ b/projects/kit/src/lib/masks/time/utils/parse-time.ts
@@ -1,6 +1,6 @@
 import {DEFAULT_TIME_SEGMENT_MAX_VALUES} from '../../../constants';
 import type {MaskitoTimeSegments} from '../../../types';
-import {padTimeSegments, parseTimeString} from '../../../utils/time';
+import {padEndTimeSegments, parseTimeString} from '../../../utils/time';
 import type {MaskitoTimeParams} from '../time-options';
 
 /**
@@ -22,7 +22,7 @@ export function maskitoParseTime(
     const msInMinute = (maxValues.seconds + 1) * msInSecond;
     const msInHour = (maxValues.minutes + 1) * msInMinute;
 
-    const parsedTime = padTimeSegments(parseTimeString(maskedTime, mode));
+    const parsedTime = padEndTimeSegments(parseTimeString(maskedTime, mode));
 
     return (
         Number(parsedTime.hours ?? '') * msInHour +

--- a/projects/kit/src/lib/masks/time/utils/stringify-time.ts
+++ b/projects/kit/src/lib/masks/time/utils/stringify-time.ts
@@ -1,6 +1,6 @@
 import {DEFAULT_TIME_SEGMENT_MAX_VALUES} from '../../../constants';
 import type {MaskitoTimeSegments} from '../../../types';
-import {padTimeSegments} from '../../../utils/time';
+import {padStartTimeSegments} from '../../../utils/time';
 import type {MaskitoTimeParams} from '../time-options';
 
 /**
@@ -34,7 +34,7 @@ export function maskitoStringifyTime(
 
     milliseconds -= seconds * msInSecond;
 
-    const result = padTimeSegments({hours, minutes, seconds, milliseconds});
+    const result = padStartTimeSegments({hours, minutes, seconds, milliseconds});
 
     return mode
         .replaceAll(/H+/g, result.hours)

--- a/projects/kit/src/lib/masks/time/utils/tests/stringify-time.spec.ts
+++ b/projects/kit/src/lib/masks/time/utils/tests/stringify-time.spec.ts
@@ -8,6 +8,7 @@ describe('maskitoStringifyTime', () => {
             'HH:MM:SS.MSS',
             [
                 {ms: 0, text: '00:00:00.000'},
+                {ms: 3661001, text: '01:01:01.001'},
                 {ms: 45296789, text: '12:34:56.789'},
                 {ms: 86399999, text: '23:59:59.999'},
             ],
@@ -16,6 +17,8 @@ describe('maskitoStringifyTime', () => {
             'HH:MM:SS',
             [
                 {ms: 0, text: '00:00:00'},
+                {ms: 3661000, text: '01:01:01'},
+                {ms: 10920000, text: '03:02:00'},
                 {ms: 45296000, text: '12:34:56'},
                 {ms: 86399000, text: '23:59:59'},
             ],
@@ -24,6 +27,7 @@ describe('maskitoStringifyTime', () => {
             'HH:MM',
             [
                 {ms: 0, text: '00:00'},
+                {ms: 3660000, text: '01:01'},
                 {ms: 45240000, text: '12:34'},
                 {ms: 86340000, text: '23:59'},
             ],
@@ -32,6 +36,7 @@ describe('maskitoStringifyTime', () => {
             'HH',
             [
                 {ms: 0, text: '00'},
+                {ms: 3600000, text: '01'},
                 {ms: 43200000, text: '12'},
                 {ms: 82800000, text: '23'},
             ],
@@ -40,7 +45,8 @@ describe('maskitoStringifyTime', () => {
             'MM.SS.MSS',
             [
                 {ms: 0, text: '00.00.000'},
-                {ms: 754560, text: '12.34.560'},
+                {ms: 61001, text: '01.01.001'},
+                {ms: 754567, text: '12.34.567'},
                 {ms: 3599999, text: '59.59.999'},
             ],
         ],
@@ -48,6 +54,7 @@ describe('maskitoStringifyTime', () => {
             'SS.MSS',
             [
                 {ms: 0, text: '00.000'},
+                {ms: 1001, text: '01.001'},
                 {ms: 12345, text: '12.345'},
                 {ms: 59999, text: '59.999'},
             ],

--- a/projects/kit/src/lib/utils/time/index.ts
+++ b/projects/kit/src/lib/utils/time/index.ts
@@ -1,4 +1,5 @@
-export * from './pad-time-segments';
+export * from './pad-end-time-segments';
+export * from './pad-start-time-segments';
 export * from './parse-time-string';
 export * from './to-time-string';
 export * from './validate-time-string';

--- a/projects/kit/src/lib/utils/time/pad-end-time-segments.ts
+++ b/projects/kit/src/lib/utils/time/pad-end-time-segments.ts
@@ -1,0 +1,16 @@
+import type {MaskitoTimeSegments} from '../../types';
+import {padTimeSegments} from './pad-time-segments';
+
+export function padEndTimeSegments(
+    timeSegments: MaskitoTimeSegments<number | string>,
+): MaskitoTimeSegments;
+
+export function padEndTimeSegments(
+    timeSegments: Partial<MaskitoTimeSegments<number | string>>,
+): Partial<MaskitoTimeSegments>;
+
+export function padEndTimeSegments(
+    timeSegments: Partial<MaskitoTimeSegments<number | string>>,
+): Partial<MaskitoTimeSegments> {
+    return padTimeSegments(timeSegments, (value, length) => value.padEnd(length, '0'));
+}

--- a/projects/kit/src/lib/utils/time/pad-start-time-segments.ts
+++ b/projects/kit/src/lib/utils/time/pad-start-time-segments.ts
@@ -1,0 +1,16 @@
+import type {MaskitoTimeSegments} from '../../types';
+import {padTimeSegments} from './pad-time-segments';
+
+export function padStartTimeSegments(
+    timeSegments: MaskitoTimeSegments<number | string>,
+): MaskitoTimeSegments;
+
+export function padStartTimeSegments(
+    timeSegments: Partial<MaskitoTimeSegments<number | string>>,
+): Partial<MaskitoTimeSegments>;
+
+export function padStartTimeSegments(
+    timeSegments: Partial<MaskitoTimeSegments<number | string>>,
+): Partial<MaskitoTimeSegments> {
+    return padTimeSegments(timeSegments, (value, length) => value.padStart(length, '0'));
+}

--- a/projects/kit/src/lib/utils/time/pad-time-segments.ts
+++ b/projects/kit/src/lib/utils/time/pad-time-segments.ts
@@ -3,21 +3,24 @@ import type {MaskitoTimeSegments} from '../../types';
 
 export function padTimeSegments(
     timeSegments: MaskitoTimeSegments<number | string>,
+    pad: (segmentValue: string, segmentLength: number) => string,
 ): MaskitoTimeSegments;
 
 export function padTimeSegments(
     timeSegments: Partial<MaskitoTimeSegments<number | string>>,
+    pad: (segmentValue: string, segmentLength: number) => string,
 ): Partial<MaskitoTimeSegments>;
 
 export function padTimeSegments(
     timeSegments: Partial<MaskitoTimeSegments<number | string>>,
+    pad: (segmentValue: string, segmentLength: number) => string,
 ): Partial<MaskitoTimeSegments> {
-    return Object.fromEntries(
+    return Object.fromEntries<string>(
         Object.entries(timeSegments).map(([segmentName, segmentValue]) => [
             segmentName,
-            `${segmentValue}`.padEnd(
+            pad(
+                String(segmentValue),
                 TIME_SEGMENT_VALUE_LENGTHS[segmentName as keyof MaskitoTimeSegments],
-                '0',
             ),
         ]),
     );


### PR DESCRIPTION
Closes #1399
