### PR TITLE
fix(kit): `Placeholder` should support partial programmatic removal of placeholder's characters

### DIFF
--- a/projects/demo-integrations/src/tests/component-testing/placeholder/placeholder-partial-removal-on-blur.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/placeholder/placeholder-partial-removal-on-blur.cy.ts
@@ -1,0 +1,92 @@
+import type {MaskitoOptions} from '@maskito/core';
+import {maskitoUpdateElement} from '@maskito/core';
+import {maskitoEventHandler, maskitoWithPlaceholder} from '@maskito/kit';
+
+import {TestInput} from '../utils';
+
+describe('Placeholder | partial removal of placeholder characters on blur', () => {
+    const PLACEHOLDER = 'xx xx xx xx##';
+    const {plugins, ...rest} = maskitoWithPlaceholder(PLACEHOLDER);
+
+    const maskitoOptions: MaskitoOptions = {
+        ...rest,
+        mask: PLACEHOLDER.split('').map((x) => (x === 'x' || x === '#' ? /\d/ : x)),
+        plugins: [
+            ...plugins,
+            maskitoEventHandler('focus', (element) => {
+                const value = element.value || '';
+
+                maskitoUpdateElement(element, value + PLACEHOLDER.slice(value.length));
+            }),
+            maskitoEventHandler('blur', (element) =>
+                maskitoUpdateElement(element, element.value.replaceAll('#', '')),
+            ),
+        ],
+    };
+
+    beforeEach(() => {
+        cy.mount(TestInput, {
+            componentProperties: {
+                maskitoOptions,
+            },
+        });
+    });
+
+    it('Empty => focus => show full placeholder', () => {
+        cy.get('input')
+            .should('have.value', '')
+            .focus()
+            .should('have.value', PLACEHOLDER);
+    });
+
+    [
+        {typedCharacters: '99', formattedValue: '99 xx xx xx##', caretIndex: '99'.length},
+        {
+            typedCharacters: '9988',
+            formattedValue: '99 88 xx xx##',
+            caretIndex: '99 88'.length,
+        },
+        {
+            typedCharacters: '99887',
+            formattedValue: '99 88 7x xx##',
+            caretIndex: '99 88 7'.length,
+        },
+        {
+            typedCharacters: '998877',
+            formattedValue: '99 88 77 xx##',
+            caretIndex: '99 88 77'.length,
+        },
+        {
+            typedCharacters: '99887766',
+            formattedValue: '99 88 77 66##',
+            caretIndex: '99 88 77 66'.length,
+        },
+        {
+            typedCharacters: '998877665',
+            formattedValue: '99 88 77 665#',
+            caretIndex: '99 88 77 665'.length,
+        },
+        {
+            typedCharacters: '9988776654',
+            formattedValue: '99 88 77 6654',
+            caretIndex: '99 88 77 6654'.length,
+        },
+    ].forEach(({typedCharacters, formattedValue, caretIndex}) => {
+        it(`Only placeholder characters => Type ${typedCharacters} => ${formattedValue}`, () => {
+            cy.get('input')
+                .type(typedCharacters)
+                .should('have.value', formattedValue)
+                .should('have.prop', 'selectionStart', caretIndex)
+                .should('have.prop', 'selectionEnd', caretIndex);
+        });
+
+        const withoutHashtags = formattedValue.replaceAll('#', '');
+
+        it(`Focused textfield with ${formattedValue} => Blur => ${withoutHashtags}`, () => {
+            cy.get('input')
+                .type(typedCharacters)
+                .blur()
+                .should('have.value', withoutHashtags);
+        });
+    });
+});

--- a/projects/kit/src/lib/processors/tests/with-placeholder.spec.ts
+++ b/projects/kit/src/lib/processors/tests/with-placeholder.spec.ts
@@ -28,17 +28,30 @@ describe('maskitoWithPlaceholder("dd/mm/yyyy")', () => {
         };
 
         it('empty', () => check('', ''));
+
         it('2/mm/yyyy => 2', () => check('2d/mm/yyyy', '2'));
+
         it('26/mm/yyyy => 26', () => check('26/mm/yyyy', '26'));
+
         it('26/0m/yyyy => 26/0', () => check('26/0m/yyyy', '26/0'));
+
         it('26/01/yyyy => 26/01', () => check('26/01/yyyy', '26/01'));
+
         it('26/01/1yyy => 26/01/1', () => check('26/01/1yyy', '26/01/1'));
+
         it('26/01/19yy => 26/01/19', () => check('26/01/19yy', '26/01/19'));
+
         it('26/01/199y => 26/01/199', () => check('26/01/199y', '26/01/199'));
+
         it('26/01/1997 => 26/01/1997', () => check('26/01/1997', '26/01/1997'));
     });
 
     describe('postprocessors', () => {
+        beforeEach(() => {
+            // Reset side effects from other tests
+            preprocessor({elementState: EMPTY_ELEMENT_STATE, data: ''}, 'validation');
+        });
+
         describe('different initial element state (2nd argument of postprocessor)', () => {
             const ONLY_PLACEHOLDER_STATE = {
                 value: 'dd/mm/yyyy',
@@ -60,12 +73,19 @@ describe('maskitoWithPlaceholder("dd/mm/yyyy")', () => {
 
                 describe(`Initial element value is "${initialState.value}"`, () => {
                     it('1 => 1d/mm/yyyy', () => check('1', '1d/mm/yyyy'));
+
                     it('16 => 16/mm/yyyy', () => check('16', '16/mm/yyyy'));
+
                     it('16/0 => 16/0m/yyyy', () => check('16/0', '16/0m/yyyy'));
+
                     it('16/05 => 16/05/yyyy', () => check('16/05', '16/05/yyyy'));
+
                     it('16/05/2 => 16/05/2yyy', () => check('16/05/2', '16/05/2yyy'));
+
                     it('16/05/20 => 16/05/20yy', () => check('16/05/20', '16/05/20yy'));
+
                     it('16/05/202 => 16/05/202y', () => check('16/05/202', '16/05/202y'));
+
                     it('16/05/2023 => 16/05/2023', () =>
                         check('16/05/2023', '16/05/2023'));
                 });

--- a/projects/kit/src/lib/processors/with-placeholder.ts
+++ b/projects/kit/src/lib/processors/with-placeholder.ts
@@ -70,16 +70,28 @@ export function maskitoWithPlaceholder(
             ({value, selection}, initialElementState) => {
                 lastClearValue = value;
 
-                /**
-                 * If `value` still equals to `initialElementState.value`,
-                 * then it means that value is patched programmatically (from Maskito's plugin or externally).
-                 * In this case, we don't want to mutate value and automatically add placeholder.
-                 * ___
-                 * For example, developer wants to remove manually placeholder (+ do something else with value) on blur.
-                 * Without this condition, placeholder will be unexpectedly added again.
-                 */
+                const justPlaceholderRemoval =
+                    value +
+                        placeholder.slice(
+                            value.length,
+                            initialElementState.value.length,
+                        ) ===
+                    initialElementState.value;
+
+                if (action === 'validation' && justPlaceholderRemoval) {
+                    /**
+                     * If `value` still equals to `initialElementState.value`,
+                     * then it means that value is patched programmatically (from Maskito's plugin or externally).
+                     * In this case, we don't want to mutate value and automatically add/remove placeholder.
+                     * ___
+                     * For example, developer wants to remove manually placeholder (+ do something else with value) on blur.
+                     * Without this condition, placeholder will be unexpectedly added again.
+                     */
+                    return {selection, value: initialElementState.value};
+                }
+
                 const newValue =
-                    value !== initialElementState.value && (focused || !focusedOnly)
+                    focused || !focusedOnly
                         ? value + placeholder.slice(value.length)
                         : value;
 


### PR DESCRIPTION
## Problem
```ts
const PLACEHOLDER = 'xx xx xx xx##';
const { plugins, ...rest } = maskitoWithPlaceholder(PLACEHOLDER);

const mask: MaskitoOptions = {
  ...rest,
  mask: PLACEHOLDER.split('').map((x) => (x === 'x' || x === '#' ? /\d/ : x)),
  plugins: [
    ...plugins,
    maskitoEventHandler('focus', (element) => {
      const initialValue = element.value || '';

      maskitoUpdateElement(
        element,
        initialValue + PLACEHOLDER.slice(initialValue.length)
      );
    }),
    maskitoEventHandler('blur', (element) =>
      maskitoUpdateElement(element, element.value.replace(/#/g, ''))
    ),
  ],
};
```

Enter incomplete value and blur => the textfield's value still includes `#` (despite logic inside `maskitoEventHandler('blue')`!).

Explore the following reproduction:
* https://stackblitz.com/edit/maskito-issue-1441