### PR TITLE
chore(demo): add `@maskito/phone` dependency to StackBlitz

### DIFF
--- a/projects/demo/src/pages/stackblitz/stackblitz.service.ts
+++ b/projects/demo/src/pages/stackblitz/stackblitz.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@angular/core';
 import {DocExamplePrimaryTab} from '@demo/constants';
+import phonePackageJson from '@maskito/phone/package.json';
 import type {OpenOptions, Project} from '@stackblitz/sdk';
 import stackblitz from '@stackblitz/sdk';
 import type {TuiCodeEditor} from '@taiga-ui/addon-doc';
@@ -15,6 +16,8 @@ export class StackblitzService implements TuiCodeEditor {
         dependencies: {
             '@maskito/core': 'latest',
             '@maskito/kit': 'latest',
+            '@maskito/phone': 'latest',
+            'libphonenumber-js': phonePackageJson.peerDependencies['libphonenumber-js'],
         },
     };
 


### PR DESCRIPTION
Open StackBlitz of this example:
https://maskito.dev/addons/phone#basic

It throws 
<img width="517" alt="Снимок экрана 2024-08-16 в 12 52 43" src="https://github.com/user-attachments/assets/359304e3-eb33-4f71-a435-64a46bdcab90">
