### PR TITLE
refactor: add support for `verbatimModuleSyntax: true`

### DIFF
--- a/projects/core/src/index.ts
+++ b/projects/core/src/index.ts
@@ -8,7 +8,7 @@ export {
     maskitoInitialCalibrationPlugin,
     maskitoStrictCompositionPlugin,
 } from './lib/plugins';
-export {
+export type {
     MaskitoElement,
     MaskitoElementPredicate,
     MaskitoMask,

--- a/projects/kit/src/index.ts
+++ b/projects/kit/src/index.ts
@@ -6,7 +6,7 @@ export {
     maskitoParseTime,
     maskitoStringifyTime,
     maskitoTimeOptionsGenerator,
-    MaskitoTimeParams,
+    type MaskitoTimeParams,
 } from './lib/masks/time';
 export {
     maskitoAddOnFocusPlugin,
@@ -20,7 +20,7 @@ export {
     maskitoPrefixPostprocessorGenerator,
     maskitoWithPlaceholder,
 } from './lib/processors';
-export {
+export type {
     MaskitoDateMode,
     MaskitoDateSegments,
     MaskitoTimeMode,

--- a/projects/kit/src/lib/masks/time/index.ts
+++ b/projects/kit/src/lib/masks/time/index.ts
@@ -1,3 +1,3 @@
 export {maskitoTimeOptionsGenerator} from './time-mask';
-export {MaskitoTimeParams} from './time-options';
+export type {MaskitoTimeParams} from './time-options';
 export {maskitoParseTime, maskitoStringifyTime} from './utils';


### PR DESCRIPTION
Fix the following errors:
```
 Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'
```

https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax

Relates:
* https://github.com/taiga-family/linters/commit/8b23332fab807731c4e575d3ef64dc27cd8f35ef