### PR TITLE
chore: add `verbatimModuleSyntax: false` to `tsconfig.spec.json`

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "./out-tsc/spec",
         "module": "esnext",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "verbatimModuleSyntax": false
     },
     "exclude": ["**/schematics/**/*", "projects/demo-integrations"],
     "include": ["**/*.spec.ts", "**/*.d.ts", "**/*.spec.tsx"]


### PR DESCRIPTION
```
projects/core/src/lib/utils/test/get-word-selection.spec.ts:1:27 - error
TS1286: ESM syntax is not allowed in a CommonJS module when 'verbatimModuleSyntax' is enabled.

import {describe, expect, it} from '@jest/globals';
```