### PR TITLE
Revert "ci: add temporary fallback command for unsuccessful npm publish (#1698)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "*** Cypress ***": "",
         "cy:open": "cypress open --project ./projects/demo-integrations/",
         "cy:run": "nx e2e demo-integrations",
-        "release": "npx nx run-many --target publish --all || echo \"No error\"",
+        "release": "npx nx run-many --target publish --all",
         "release:local": "npx release-it --no-git.push --'hooks.before:release=\"echo Skip publish\"'"
     },
     "commitlint": {


### PR DESCRIPTION
This reverts commit 240223b0513d67fb5509fffb8ebff5fa84204200.

