### PR TITLE
fix(kit): `Number` should ignore `[decimalSeparator]` value if `[precision]=0`

### DIFF
--- a/projects/demo-integrations/src/tests/kit/number/number-precision.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/number/number-precision.cy.ts
@@ -48,20 +48,41 @@ describe('Number | precision', () => {
     });
 
     describe('rejects decimal separator if `precision` is equal to 0', () => {
-        beforeEach(() => {
-            openNumberPage('decimalSeparator=,&precision=0');
-        });
-
         it('empty input => Type "," => Empty input', () => {
+            openNumberPage('decimalSeparator=,&precision=0');
             cy.get('@input').type(',').should('have.value', '');
         });
 
         it('Type "5," => "5"', () => {
+            openNumberPage('decimalSeparator=,&precision=0');
+
             cy.get('@input')
                 .type('5,')
                 .should('have.value', '5')
                 .should('have.prop', 'selectionStart', 1)
                 .should('have.prop', 'selectionEnd', 1);
+        });
+
+        describe('dont rejects thousand separator if it is equal to decimal separator (for precision=0 value of decimal separator does not matter)', () => {
+            it('simple typing', () => {
+                openNumberPage('precision=0&thousandSeparator=.&decimalSeparator=.');
+
+                cy.get('@input')
+                    .type('1234')
+                    .should('have.value', '1.234')
+                    .should('have.prop', 'selectionStart', '1.234'.length)
+                    .should('have.prop', 'selectionEnd', '1.234'.length);
+            });
+
+            it('paste from clipboard', () => {
+                openNumberPage('precision=0&thousandSeparator=.&decimalSeparator=.');
+
+                cy.get('@input')
+                    .paste('1.234')
+                    .should('have.value', '1.234')
+                    .should('have.prop', 'selectionStart', '1.234'.length)
+                    .should('have.prop', 'selectionEnd', '1.234'.length);
+            });
         });
     });
 

--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -126,6 +126,7 @@ export function maskitoNumberOptionsGenerator({
             createZeroPrecisionPreprocessor({
                 precision,
                 decimalSeparator,
+                thousandSeparator,
                 prefix,
                 postfix,
             }),
@@ -136,11 +137,16 @@ export function maskitoNumberOptionsGenerator({
             }),
         ],
         postprocessors: [
-            createMinMaxPostprocessor({decimalSeparator, min, max, minusSign}),
+            createMinMaxPostprocessor({
+                min,
+                max,
+                minusSign,
+                decimalSeparator: precision ? decimalSeparator : '',
+            }),
             maskitoPrefixPostprocessorGenerator(prefix),
             maskitoPostfixPostprocessorGenerator(postfix),
             createThousandSeparatorPostprocessor({
-                decimalSeparator,
+                decimalSeparator: precision ? decimalSeparator : '',
                 thousandSeparator,
                 prefix,
                 postfix,
@@ -156,7 +162,7 @@ export function maskitoNumberOptionsGenerator({
             emptyPostprocessor({
                 prefix,
                 postfix,
-                decimalSeparator,
+                decimalSeparator: precision ? decimalSeparator : '',
                 minusSign,
             }),
         ],

--- a/projects/kit/src/lib/masks/number/processors/empty-postprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/empty-postprocessor.ts
@@ -31,7 +31,10 @@ export function emptyPostprocessor({
             minusSign,
         });
         const aloneDecimalSeparator =
-            !integerPart && !decimalPart && cleanValue.includes(decimalSeparator);
+            !integerPart &&
+            !decimalPart &&
+            Boolean(decimalSeparator) &&
+            cleanValue.includes(decimalSeparator);
 
         if (
             (!integerPart &&

--- a/projects/kit/src/lib/masks/number/processors/thousand-separator-postprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/thousand-separator-postprocessor.ts
@@ -39,14 +39,14 @@ export function createThousandSeparatorPostprocessor({
             decimalSeparator,
             minusSign,
         });
+        const hasDecimalSeparator =
+            decimalSeparator && cleanValue.includes(decimalSeparator);
         const deletedChars =
             cleanValue.length -
             (
                 minus +
                 integerPart +
-                (cleanValue.includes(decimalSeparator)
-                    ? decimalSeparator + decimalPart
-                    : '')
+                (hasDecimalSeparator ? decimalSeparator + decimalPart : '')
             ).length;
 
         if (deletedChars > 0 && initialFrom && initialFrom <= deletedChars) {
@@ -105,7 +105,7 @@ export function createThousandSeparatorPostprocessor({
                 extractedPrefix +
                 minus +
                 processedIntegerPart +
-                (cleanValue.includes(decimalSeparator) ? decimalSeparator : '') +
+                (hasDecimalSeparator ? decimalSeparator : '') +
                 decimalPart +
                 extractedPostfix,
             selection: [from, to],

--- a/projects/kit/src/lib/masks/number/processors/zero-precision-preprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/zero-precision-preprocessor.ts
@@ -9,15 +9,20 @@ import {escapeRegExp, extractAffixes, identity} from '../../../utils';
 export function createZeroPrecisionPreprocessor({
     precision,
     decimalSeparator,
+    thousandSeparator,
     prefix,
     postfix,
 }: {
     precision: number;
     decimalSeparator: string;
+    thousandSeparator: string;
     prefix: string;
     postfix: string;
 }): MaskitoPreprocessor {
-    if (precision > 0) {
+    if (
+        precision > 0 ||
+        thousandSeparator === decimalSeparator // all separators should be treated only as thousand separators
+    ) {
         return identity;
     }
 

--- a/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
+++ b/projects/kit/src/lib/masks/number/tests/number-mask.spec.ts
@@ -405,4 +405,14 @@ describe('Number (maskitoTransform)', () => {
 
         expect(maskitoTransform('    123456    ', options)).toBe('123 456');
     });
+
+    it('[thousandSeparator] is equal to [decimalSeparator] when [precision]=0', () => {
+        const options = maskitoNumberOptionsGenerator({
+            thousandSeparator: '.',
+            decimalSeparator: '.', // default value
+            precision: 0, // default value
+        });
+
+        expect(maskitoTransform('123.456', options)).toBe('123.456');
+    });
 });

--- a/projects/kit/src/lib/masks/number/utils/parse-number.ts
+++ b/projects/kit/src/lib/masks/number/utils/parse-number.ts
@@ -18,7 +18,7 @@ export function maskitoParseNumber(maskedNumber: string, decimalSeparator = '.')
         .replaceAll(new RegExp(`${escapedDecimalSeparator}(?!\\d)`, 'g'), '')
         // drop all non-digit characters except decimal separator
         .replaceAll(new RegExp(`[^\\d${escapedDecimalSeparator}]`, 'g'), '')
-        .replace(decimalSeparator, '.');
+        .replace(decimalSeparator, decimalSeparator && '.');
 
     if (unmaskedNumber) {
         const sign = hasNegativeSign ? CHAR_HYPHEN : '';

--- a/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
@@ -54,6 +54,16 @@ describe('maskitoParseNumber', () => {
         });
     });
 
+    describe('decimal separator is empty string', () => {
+        it('thousand separator is point', () => {
+            expect(maskitoParseNumber('123.456.789', '')).toBe(123456789);
+        });
+
+        it('thousand separator is empty string', () => {
+            expect(maskitoParseNumber('123456', '')).toBe(123456);
+        });
+    });
+
     describe('negative numbers', () => {
         describe('minus sign', () => {
             it('can be minus', () => {

--- a/projects/kit/src/lib/masks/number/utils/to-number-parts.ts
+++ b/projects/kit/src/lib/masks/number/utils/to-number-parts.ts
@@ -4,7 +4,9 @@ export function toNumberParts(
     value: string,
     {decimalSeparator, minusSign}: {decimalSeparator: string; minusSign: string},
 ): {minus: string; integerPart: string; decimalPart: string} {
-    const [integerWithMinus = '', decimalPart = ''] = value.split(decimalSeparator);
+    const [integerWithMinus = '', decimalPart = ''] = decimalSeparator
+        ? value.split(decimalSeparator)
+        : [value];
     const escapedMinus = escapeRegExp(minusSign);
     const [, minus = '', integerPart = ''] =
         new RegExp(`^(?:[^\\d${escapedMinus}])?(${escapedMinus})?(.*)`).exec(


### PR DESCRIPTION
Fixes #1907
