### PR TITLE
fix(kit): `SelectionChangeHandler` does not work for Safari after programmatic update of textfield value

### DIFF
--- a/projects/kit/src/lib/plugins/selection-change.ts
+++ b/projects/kit/src/lib/plugins/selection-change.ts
@@ -27,12 +27,15 @@ export function maskitoSelectionChangeHandler(
         };
 
         document.addEventListener('selectionchange', listener, {passive: true});
+        // Safari does not fire `selectionchange` on focus after programmatic update of textfield value
+        element.addEventListener('focus', listener, {passive: true});
         element.addEventListener('mousedown', onPointerDown, {passive: true});
         document.addEventListener('mouseup', onPointerUp, {passive: true});
 
         return () => {
             document.removeEventListener('selectionchange', listener);
-            document.removeEventListener('mousedown', onPointerDown);
+            element.removeEventListener('focus', listener);
+            element.removeEventListener('mousedown', onPointerDown);
             document.removeEventListener('mouseup', onPointerUp);
         };
     };


### PR DESCRIPTION
Fixes #1929
