### PR TITLE
chore: update `keywords` for publishable libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "3.3.0",
     "description": "Collection of libraries to create an input mask which ensures that user types value according to predefined format",
     "keywords": [
+        "input",
         "mask",
         "inputmask",
         "input-mask",
@@ -10,7 +11,8 @@
         "input-formatting",
         "javascript",
         "typescript",
-        "angular"
+        "angular",
+        "react"
     ],
     "homepage": "https://maskito.dev",
     "bugs": "https://github.com/taiga-family/maskito/issues",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "name": "maskito",
     "version": "3.3.0",
     "description": "Collection of libraries to create an input mask which ensures that user types value according to predefined format",
-    "keywords": [],
     "homepage": "https://maskito.dev",
     "bugs": "https://github.com/taiga-family/maskito/issues",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -2,18 +2,7 @@
     "name": "maskito",
     "version": "3.3.0",
     "description": "Collection of libraries to create an input mask which ensures that user types value according to predefined format",
-    "keywords": [
-        "input",
-        "mask",
-        "inputmask",
-        "input-mask",
-        "text-mask",
-        "input-formatting",
-        "javascript",
-        "typescript",
-        "angular",
-        "react"
-    ],
+    "keywords": [],
     "homepage": "https://maskito.dev",
     "bugs": "https://github.com/taiga-family/maskito/issues",
     "repository": {

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -3,10 +3,13 @@
     "version": "3.3.0",
     "description": "The Angular-specific Maskito's library",
     "keywords": [
+        "input",
         "mask",
         "inputmask",
         "input-mask",
         "text-mask",
+        "format",
+        "input-format",
         "input-formatting",
         "angular"
     ],

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -8,10 +8,11 @@
         "inputmask",
         "input-mask",
         "text-mask",
+        "format",
+        "input-format",
         "input-formatting",
         "javascript",
-        "typescript",
-        "react",
+        "typescript"
     ],
     "homepage": "https://maskito.dev",
     "bugs": "https://github.com/taiga-family/maskito/issues",

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -3,13 +3,15 @@
     "version": "3.3.0",
     "description": "The main zero-dependency and framework-agnostic Maskito's package to create an input mask",
     "keywords": [
+        "input",
         "mask",
         "inputmask",
         "input-mask",
         "text-mask",
         "input-formatting",
         "javascript",
-        "typescript"
+        "typescript",
+        "react",
     ],
     "homepage": "https://maskito.dev",
     "bugs": "https://github.com/taiga-family/maskito/issues",

--- a/projects/kit/package.json
+++ b/projects/kit/package.json
@@ -3,10 +3,13 @@
     "version": "3.3.0",
     "description": "The optional framework-agnostic Maskito's package with ready-to-use masks",
     "keywords": [
+        "input",
         "mask",
         "inputmask",
         "input-mask",
         "text-mask",
+        "format",
+        "input-format",
         "input-formatting",
         "javascript",
         "typescript"

--- a/projects/phone/package.json
+++ b/projects/phone/package.json
@@ -3,10 +3,16 @@
     "version": "3.3.0",
     "description": "The optional framework-agnostic Maskito's package with phone masks",
     "keywords": [
+        "input",
         "mask",
         "inputmask",
-        "phonemask",
+        "input-mask",
         "phone",
+        "phonemask",
+        "phone-mask",
+        "format",
+        "input-format",
+        "input-formatting",
         "javascript",
         "typescript"
     ],

--- a/projects/react/package.json
+++ b/projects/react/package.json
@@ -3,10 +3,13 @@
     "version": "3.3.0",
     "description": "The React-specific Maskito's library",
     "keywords": [
+        "input",
         "mask",
         "inputmask",
         "input-mask",
         "text-mask",
+        "format",
+        "input-format",
         "input-formatting",
         "react"
     ],

--- a/projects/vue/package.json
+++ b/projects/vue/package.json
@@ -8,7 +8,7 @@
         "inputmask",
         "input-mask",
         "text-mask",
-        "fomrat",
+        "format",
         "input-format",
         "input-formatting",
         "vue"

--- a/projects/vue/package.json
+++ b/projects/vue/package.json
@@ -3,10 +3,13 @@
     "version": "3.3.0",
     "description": "The Vue-specific Maskito's library",
     "keywords": [
+        "input",
         "mask",
         "inputmask",
         "input-mask",
         "text-mask",
+        "fomrat",
+        "input-format",
         "input-formatting",
         "vue"
     ],


### PR DESCRIPTION
### Resume
I was looking for an updated library to perform input masking in react using the proposed keywords. I could only find this library after having reached “text-mask” through reddit and seeing it as an option in the list of alternatives.

It seems to me that by updating the list of keywords (I don't know if there are restrictions on the number or content) the library could have more visibility and more contributors, which it deserves since it managed to solve my problems.

### Evidence
> Not required

### Reference
> Not required
