### PR TITLE
feat(kit): `Time` supports `MM:SS` mode

### DIFF
--- a/projects/demo-integrations/src/tests/kit/time/time-mode.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/time/time-mode.cy.ts
@@ -648,5 +648,112 @@ describe('Time', () => {
                 cy.get('@input').type('59999').should('have.value', '59.999');
             });
         });
+
+        describe('MM:SS', () => {
+            beforeEach(() => {
+                cy.visit(`/${DemoPath.Time}/API?mode=MM:SS`);
+                cy.get('#demo-content input')
+                    .should('be.visible')
+                    .first()
+                    .focus()
+                    .clear()
+                    .as('input');
+            });
+
+            describe('Typing new character overwrite character after cursor', () => {
+                it('new character is different from the next one', () => {
+                    cy.get('@input')
+                        .type('59:59')
+                        .type('{moveToStart}')
+                        .type('0')
+                        .should('have.value', '09:59')
+                        .should('have.prop', 'selectionStart', '0'.length)
+                        .should('have.prop', 'selectionEnd', '0'.length)
+                        .type('0')
+                        .should('have.value', '00:59')
+                        .should('have.prop', 'selectionStart', '00:'.length)
+                        .should('have.prop', 'selectionEnd', '00:'.length)
+                        .type('00')
+                        .should('have.value', '00:00')
+                        .should('have.prop', 'selectionStart', '00:00'.length)
+                        .should('have.prop', 'selectionEnd', '00:00'.length);
+                });
+
+                it('moves cursor behind next character if new character is the same with the next one', () => {
+                    cy.get('@input')
+                        .type('59:59')
+                        .type('{moveToStart}')
+                        .type('{rightArrow}'.repeat('59:'.length))
+                        .type('59')
+                        .should('have.value', '59:59')
+                        .should('have.prop', 'selectionStart', '59:59'.length)
+                        .should('have.prop', 'selectionEnd', '59:59'.length);
+                });
+            });
+
+            it('Pad typed value with zero if digit exceeds the first digit of time segment', () => {
+                cy.get('@input')
+                    .type('6')
+                    .should('have.value', '06')
+                    .should('have.prop', 'selectionStart', '06'.length)
+                    .should('have.prop', 'selectionEnd', '06'.length)
+                    .type('9')
+                    .should('have.value', '06:09')
+                    .should('have.prop', 'selectionStart', '06:09'.length)
+                    .should('have.prop', 'selectionEnd', '06:09'.length);
+            });
+
+            describe('Select range and press new digit', () => {
+                it('|59|:59 => Type 2 => 2|0:59', BROWSER_SUPPORTS_REAL_EVENTS, () => {
+                    cy.get('@input')
+                        .type('5959')
+                        .should('have.value', '59:59')
+                        .realPress([
+                            ...new Array(':59'.length).fill('ArrowLeft'),
+                            'Shift',
+                            ...new Array('59'.length).fill('ArrowLeft'),
+                        ]);
+
+                    cy.get('@input')
+                        .type('2')
+                        .should('have.value', '20:59')
+                        .should('have.prop', 'selectionStart', '2'.length)
+                        .should('have.prop', 'selectionEnd', '2'.length);
+                });
+
+                it('|59|:59 => Type 6 => 06:|59', BROWSER_SUPPORTS_REAL_EVENTS, () => {
+                    cy.get('@input')
+                        .type('5959')
+                        .should('have.value', '59:59')
+                        .realPress([
+                            ...new Array(':59'.length).fill('ArrowLeft'),
+                            'Shift',
+                            ...new Array('59'.length).fill('ArrowLeft'),
+                        ]);
+
+                    cy.get('@input')
+                        .type('6')
+                        .should('have.value', '06:59')
+                        .should('have.prop', 'selectionStart', '06:'.length)
+                        .should('have.prop', 'selectionEnd', '06:'.length);
+                });
+            });
+
+            describe('accepts time segment separators typed by user', () => {
+                it('59 => Type : => 59:', () => {
+                    cy.get('@input')
+                        .type('59')
+                        .should('have.value', '59')
+                        .type(':')
+                        .should('have.value', '59:')
+                        .should('have.prop', 'selectionStart', '59:'.length)
+                        .should('have.prop', 'selectionEnd', '59:'.length);
+                });
+            });
+
+            it('type 9999 => 09:09', () => {
+                cy.get('@input').type('9999').should('have.value', '09:09');
+            });
+        });
     });
 });

--- a/projects/demo/src/pages/kit/time/time-mask-doc.component.ts
+++ b/projects/demo/src/pages/kit/time/time-mask-doc.component.ts
@@ -77,6 +77,7 @@ export default class TimeMaskDocComponent implements GeneratorOptions {
         'HH AA',
         'MM:SS.MSS',
         'SS.MSS',
+        'MM:SS',
     ] as const satisfies readonly MaskitoTimeMode[];
 
     protected readonly timeSegmentMaxValuesOptions = [

--- a/projects/kit/src/lib/masks/time/utils/tests/parse-time.spec.ts
+++ b/projects/kit/src/lib/masks/time/utils/tests/parse-time.spec.ts
@@ -108,6 +108,18 @@ describe('maskitoParseTime', () => {
             ],
         ],
         [
+            'MM:SS',
+            [
+                {text: '', ms: 0},
+                {text: '1', ms: 600000},
+                {text: '10', ms: 600000},
+                {text: '12', ms: 720000},
+                {text: '12:', ms: 720000},
+                {text: '12:3', ms: 750000},
+                {text: '12:30', ms: 750000},
+            ],
+        ],
+        [
             'SS.MSS',
             [
                 {text: '', ms: 0},

--- a/projects/kit/src/lib/masks/time/utils/tests/stringify-time.spec.ts
+++ b/projects/kit/src/lib/masks/time/utils/tests/stringify-time.spec.ts
@@ -51,6 +51,15 @@ describe('maskitoStringifyTime', () => {
             ],
         ],
         [
+            'MM:SS',
+            [
+                {ms: 0, text: '00:00'},
+                {ms: 60000, text: '01:00'},
+                {ms: 600000, text: '10:00'},
+                {ms: 750000, text: '12:30'},
+            ],
+        ],
+        [
             'SS.MSS',
             [
                 {ms: 0, text: '00.000'},

--- a/projects/kit/src/lib/types/time-mode.ts
+++ b/projects/kit/src/lib/types/time-mode.ts
@@ -8,5 +8,6 @@ export type MaskitoTimeMode =
     | 'HH:MM'
     | 'HH'
     | 'MM:SS.MSS'
+    | 'MM:SS'
     | 'MM.SS.MSS' // TODO: delete in v4
     | 'SS.MSS';

--- a/projects/kit/src/lib/utils/time/tests/parse-time-string.spec.ts
+++ b/projects/kit/src/lib/utils/time/tests/parse-time-string.spec.ts
@@ -47,4 +47,11 @@ describe('parseTimeString', () => {
             milliseconds: '999',
         });
     });
+
+    it('mm:ss', () => {
+        expect(parseTimeString('25:55', 'MM:SS')).toEqual({
+            minutes: '25',
+            seconds: '55',
+        });
+    });
 });

--- a/projects/kit/src/lib/utils/time/tests/to-time-string.spec.ts
+++ b/projects/kit/src/lib/utils/time/tests/to-time-string.spec.ts
@@ -132,4 +132,33 @@ describe('toTimeString', () => {
             ).toBe('02.91');
         });
     });
+
+    describe('MM:SS', () => {
+        it('12:11', () => {
+            expect(
+                toTimeString({
+                    minutes: '12',
+                    seconds: '11',
+                }),
+            ).toBe('12:11');
+        });
+
+        it('01:09', () => {
+            expect(
+                toTimeString({
+                    minutes: '01',
+                    seconds: '09',
+                }),
+            ).toBe('01:09');
+        });
+
+        it('02:55', () => {
+            expect(
+                toTimeString({
+                    minutes: '02',
+                    seconds: '55',
+                }),
+            ).toBe('02:55');
+        });
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/taiga-family/maskito/issues/1996
Hi guys. I created small PR with new  `MM:SS` mode for time kit. 
![image](https://github.com/user-attachments/assets/adf73767-1504-404d-b968-99f049798109)
