### PR TITLE
fix(kit): `maskitoParseDate` should return `null` for incompleted date string

### DIFF
--- a/projects/kit/src/lib/masks/date/utils/parse-date.ts
+++ b/projects/kit/src/lib/masks/date/utils/parse-date.ts
@@ -5,7 +5,11 @@ import type {MaskitoDateParams} from '../date-params';
 export function maskitoParseDate(
     value: string,
     {mode, min = DEFAULT_MIN_DATE, max = DEFAULT_MAX_DATE}: MaskitoDateParams,
-): Date {
+): Date | null {
+    if (value.length < mode.length) {
+        return null;
+    }
+    
     const dateSegments = parseDateString(value, mode);
 
     const parsedDate = segmentsToDate(dateSegments);

--- a/projects/kit/src/lib/masks/date/utils/parse-date.ts
+++ b/projects/kit/src/lib/masks/date/utils/parse-date.ts
@@ -9,7 +9,7 @@ export function maskitoParseDate(
     if (value.length < mode.length) {
         return null;
     }
-    
+
     const dateSegments = parseDateString(value, mode);
 
     const parsedDate = segmentsToDate(dateSegments);

--- a/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
+++ b/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
@@ -39,7 +39,7 @@ describe('maskitoParseDate', () => {
             params = {
                 mode: 'mm/dd/yyyy',
                 min: new Date('2004-02-05T00:00:00.000'),
-                max: new Date('2024-01-01T00:00:00.000'),
+                max: new Date('2024-01-03T00:00:00.000'),
             };
         });
 
@@ -76,7 +76,7 @@ describe('maskitoParseDate', () => {
         it('should return date on 01/02/2024', () => {
             const parsedDate = maskitoParseDate('01/02/2024', params);
 
-            expect(parsedDate?.getTime()).toBe(Date.parse('2024-02-01T00:00:00.000'));
+            expect(parsedDate?.getTime()).toBe(Date.parse('2024-01-02T00:00:00.000'));
         });
     });
 

--- a/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
+++ b/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
@@ -16,19 +16,19 @@ describe('maskitoParseDate', () => {
         it('should correctly parse 04/29/2012', () => {
             const parsedDate = maskitoParseDate('04/29/2012', params);
 
-            expect(parsedDate.getTime()).toBe(Date.parse('2012-04-29T00:00:00.000'));
+            expect(parsedDate?.getTime()).toBe(Date.parse('2012-04-29T00:00:00.000'));
         });
 
         it('should return min date on 02/04/2004', () => {
             const parsedDate = maskitoParseDate('02/04/2004', params);
 
-            expect(parsedDate.getTime()).toBe(params.min?.getTime());
+            expect(parsedDate?.getTime()).toBe(params.min?.getTime());
         });
 
         it('should return max date on 01/02/2024', () => {
             const parsedDate = maskitoParseDate('01/02/2024', params);
 
-            expect(parsedDate.getTime()).toBe(params.max?.getTime());
+            expect(parsedDate?.getTime()).toBe(params.max?.getTime());
         });
     });
 
@@ -46,37 +46,37 @@ describe('maskitoParseDate', () => {
         it('should return null, 04/mm/yyyy', () => {
             const parsedDate = maskitoParseDate('04', params);
 
-            expect(parsedDate).toBe(null);
+            expect(parsedDate).toBeNull();
         });
 
         it('should return null 02/04/yyyy', () => {
             const parsedDate = maskitoParseDate('02/04', params);
 
-            expect(parsedDate).toBe(null);
+            expect(parsedDate).toBeNull();
         });
 
         it('should return null 01/02/2yyy', () => {
             const parsedDate = maskitoParseDate('01/02/2', params);
 
-            expect(parsedDate).toBe(null);
+            expect(parsedDate).toBeNull();
         });
 
         it('should return null 01/02/20yy', () => {
             const parsedDate = maskitoParseDate('01/02/20', params);
 
-            expect(parsedDate).toBe(null);
+            expect(parsedDate).toBeNull();
         });
 
         it('should return null 01/02/202y', () => {
             const parsedDate = maskitoParseDate('01/02/202', params);
 
-            expect(parsedDate).toBe(null);
+            expect(parsedDate).toBeNull();
         });
 
         it('should return date on 01/02/2024', () => {
             const parsedDate = maskitoParseDate('01/02/2024', params);
 
-            expect(parsedDate.getTime()).toBe(Date.parse('2024-02-01T00:00:00.000'));
+            expect(parsedDate?.getTime()).toBe(Date.parse('2024-02-01T00:00:00.000'));
         });
     });
 
@@ -95,19 +95,19 @@ describe('maskitoParseDate', () => {
         it('should correctly parse 12-31-2020', () => {
             const parsedDate = maskitoParseDate('12-31-2020', params);
 
-            expect(parsedDate.getTime()).toBe(Date.parse('2020-12-31T00:00:00.000'));
+            expect(parsedDate?.getTime()).toBe(Date.parse('2020-12-31T00:00:00.000'));
         });
 
         it('should return min date on 02-27-2004', () => {
             const parsedDate = maskitoParseDate('02-27-2004', params);
 
-            expect(parsedDate.getTime()).toBe(params.min?.getTime());
+            expect(parsedDate?.getTime()).toBe(params.min?.getTime());
         });
 
         it('should return max date on 01/02/2030', () => {
             const parsedDate = maskitoParseDate('01/02/2030', params);
 
-            expect(parsedDate.getTime()).toBe(params.max?.getTime());
+            expect(parsedDate?.getTime()).toBe(params.max?.getTime());
         });
     });
 
@@ -126,19 +126,19 @@ describe('maskitoParseDate', () => {
         it('should correctly parse 02:12', () => {
             const parsedDate = maskitoParseDate('02:12', params);
 
-            expect(parsedDate.getTime()).toBe(Date.parse('2012-02-01T00:00:00.000'));
+            expect(parsedDate?.getTime()).toBe(Date.parse('2012-02-01T00:00:00.000'));
         });
 
         it('should return min date on 01:03', () => {
             const parsedDate = maskitoParseDate('01:03', params);
 
-            expect(parsedDate.getTime()).toBe(params.min?.getTime());
+            expect(parsedDate?.getTime()).toBe(params.min?.getTime());
         });
 
         it('should return max date on 02:31', () => {
             const parsedDate = maskitoParseDate('02:30', params);
 
-            expect(parsedDate.getTime()).toBe(params.max?.getTime());
+            expect(parsedDate?.getTime()).toBe(params.max?.getTime());
         });
     });
 
@@ -157,19 +157,19 @@ describe('maskitoParseDate', () => {
         it('should correctly parse 2012.08', () => {
             const parsedDate = maskitoParseDate('2012.08', params);
 
-            expect(parsedDate.getTime()).toBe(Date.parse('2012-08-01T00:00:00.000'));
+            expect(parsedDate?.getTime()).toBe(Date.parse('2012-08-01T00:00:00.000'));
         });
 
         it('should return min date on 1991.01', () => {
             const parsedDate = maskitoParseDate('1991.01', params);
 
-            expect(parsedDate.getTime()).toBe(params.min?.getTime());
+            expect(parsedDate?.getTime()).toBe(params.min?.getTime());
         });
 
         it('should return max date on 2033.12', () => {
             const parsedDate = maskitoParseDate('2033.12', params);
 
-            expect(parsedDate.getTime()).toBe(params.max?.getTime());
+            expect(parsedDate?.getTime()).toBe(params.max?.getTime());
         });
     });
 });

--- a/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
+++ b/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
@@ -32,6 +32,54 @@ describe('maskitoParseDate', () => {
         });
     });
 
+    describe('incomplete, mode = mm/dd/yyyy, separator = default', () => {
+        let params: MaskitoDateParams;
+
+        beforeEach(() => {
+            params = {
+                mode: 'mm/dd/yyyy',
+                min: new Date('2004-02-05T00:00:00.000'),
+                max: new Date('2024-01-01T00:00:00.000'),
+            };
+        });
+
+        it('should return null, 04/mm/yyyy', () => {
+            const parsedDate = maskitoParseDate('04', params);
+
+            expect(parsedDate).toBe(null);
+        });
+
+        it('should return null 02/04/yyyy', () => {
+            const parsedDate = maskitoParseDate('02/04', params);
+
+            expect(parsedDate).toBe(null);
+        });
+
+        it('should return null 01/02/2yyy', () => {
+            const parsedDate = maskitoParseDate('01/02/2', params);
+
+            expect(parsedDate).toBe(null);
+        });
+
+        it('should return null 01/02/20yy', () => {
+            const parsedDate = maskitoParseDate('01/02/20', params);
+
+            expect(parsedDate).toBe(null);
+        });
+
+        it('should return null 01/02/202y', () => {
+            const parsedDate = maskitoParseDate('01/02/202', params);
+
+            expect(parsedDate).toBe(null);
+        });
+
+        it('should return date on 01/02/2024', () => {
+            const parsedDate = maskitoParseDate('01/02/2024', params);
+
+            expect(parsedDate.getTime()).toBe(Date.parse('2024-02-01T00:00:00.000'));
+        });
+    });
+
     describe('mode = mm/dd/yyyy, separator = -', () => {
         let params: MaskitoDateParams;
 


### PR DESCRIPTION
### Resume
The function maskitoParseDate had to return a non-nullable Date type data, as opposed to its equivalent for the number type, which could return NaN.

This caused the function to prematurely return wrong dates, for example, following a mode of “dd/mm/yyyy”, when the first two digits of the year were completed the function already returned a premature result since it entered conditionals that correspond to other modes such as “mm/yy”.

With this pull request the return type of the function is modified as well as the expected result, until the function does not receive a string of characters of the same length as the mode of use, it will not try to parse the date.

### Evidence
> Not required

### Reference
https://github.com/taiga-family/maskito/issues/2007
