### PR TITLE
ci: run typecheck for integrations tests too

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "cspell": "cspell --relative --dot --gitignore .",
         "prettier": "prettier !package-lock.json . --ignore-path .gitignore",
         "stylelint": "stylelint '**/*.{less,css}'",
-        "typecheck": "tsc --noEmit --skipLibCheck --incremental false --tsBuildInfoFile null --project tsconfig.spec.json",
+        "typecheck": "tsc --noEmit --skipLibCheck --incremental false --tsBuildInfoFile null --project tsconfig.spec.json && tsc -p projects/demo-integrations/tsconfig.json",
         "*** SSR ***": "",
         "serve:dev:ssr": "nx run demo:serve-ssr",
         "serve:ssr": "node dist/demo/server/main.js",

--- a/projects/demo-integrations/src/tests/component-testing/angular-predicate/angular-predicate.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/angular-predicate/angular-predicate.cy.ts
@@ -2,7 +2,11 @@ import {AsyncPipe} from '@angular/common';
 import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
 import type {ComponentFixture} from '@angular/core/testing';
 import {MaskitoDirective} from '@maskito/angular';
-import type {MaskitoElementPredicate, MaskitoOptions} from '@maskito/core';
+import type {
+    MaskitoElement,
+    MaskitoElementPredicate,
+    MaskitoOptions,
+} from '@maskito/core';
 import {maskitoNumberOptionsGenerator} from '@maskito/kit';
 
 import {TestInput} from '../utils';
@@ -38,8 +42,8 @@ describe('@maskito/angular | Predicate', () => {
         cy.mount(TestInput, {
             componentProperties: {
                 maskitoOptions: cardMask,
-                maskitoElementPredicate: async (element) =>
-                    Promise.resolve(element as HTMLInputElement),
+                maskitoElementPredicate: async (element: HTMLElement) =>
+                    Promise.resolve(element as MaskitoElement),
             },
         });
         cy.get('input').as('card');


### PR DESCRIPTION
Run 
```
npm run cy:run
```

Its logs will contain the following error:
```
ERROR in src/tests/component-testing/angular-predicate/angular-predicate.cy.ts:41:49 - error
TS7006: Parameter 'element' implicitly has an 'any' type.

41                 maskitoElementPredicate: async (element) =>
                                                   ~~~~~~~
```