### PR TITLE
feat(kit): new `maskitoParseDateTime` and `maskitoStringifyDateTime` helpers

### DIFF
--- a/projects/kit/src/lib/constants/default-min-max-dates.ts
+++ b/projects/kit/src/lib/constants/default-min-max-dates.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_MIN_DATE = new Date('0001-01-01');
-export const DEFAULT_MAX_DATE = new Date('9999-12-31');
+export const DEFAULT_MIN_DATE = new Date('0001-01-01T00:00');
+export const DEFAULT_MAX_DATE = new Date('9999-12-31T23:59:59.999');

--- a/projects/kit/src/lib/masks/date-time/date-time-mask.ts
+++ b/projects/kit/src/lib/masks/date-time/date-time-mask.ts
@@ -20,9 +20,10 @@ import {
     createZeroPlaceholdersPreprocessor,
     normalizeDatePreprocessor,
 } from '../../processors';
-import type {MaskitoDateMode, MaskitoTimeMode, MaskitoTimeSegments} from '../../types';
+import type {MaskitoTimeSegments} from '../../types';
 import {createTimeMaskExpression} from '../../utils/time';
 import {DATE_TIME_SEPARATOR} from './constants';
+import type {MaskitoDateTimeParams} from './date-time-params';
 import {createMinMaxDateTimePostprocessor} from './postprocessors';
 import {createValidDateTimePreprocessor} from './preprocessors';
 import {parseDateTimeString} from './utils';
@@ -35,15 +36,7 @@ export function maskitoDateTimeOptionsGenerator({
     max,
     dateTimeSeparator = DATE_TIME_SEPARATOR,
     timeStep = 0,
-}: {
-    dateMode: MaskitoDateMode;
-    timeMode: MaskitoTimeMode;
-    dateSeparator?: string;
-    max?: Date;
-    min?: Date;
-    dateTimeSeparator?: string;
-    timeStep?: number;
-}): Required<MaskitoOptions> {
+}: MaskitoDateTimeParams): Required<MaskitoOptions> {
     const hasMeridiem = timeMode.includes('AA');
     const dateModeTemplate = dateMode.split('/').join(dateSeparator);
     const timeSegmentMaxValues: MaskitoTimeSegments<number> = {

--- a/projects/kit/src/lib/masks/date-time/date-time-params.ts
+++ b/projects/kit/src/lib/masks/date-time/date-time-params.ts
@@ -1,0 +1,11 @@
+import type {MaskitoDateMode, MaskitoTimeMode} from '../../types';
+
+export interface MaskitoDateTimeParams {
+    dateMode: MaskitoDateMode;
+    timeMode: MaskitoTimeMode;
+    dateSeparator?: string;
+    max?: Date;
+    min?: Date;
+    dateTimeSeparator?: string;
+    timeStep?: number;
+}

--- a/projects/kit/src/lib/masks/date-time/utils/parse-date-time.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/parse-date-time.ts
@@ -15,27 +15,16 @@ export function maskitoParseDateTime(
         dateTimeSeparator = DATE_TIME_SEPARATOR,
     }: MaskitoDateTimeParams,
 ): Date | null {
-    const modeLength = dateMode.length + dateTimeSeparator.length + timeMode.length;
+    const [dateSegment = '', timeSegment = ''] = value.split(dateTimeSeparator);
 
-    if (value.length !== modeLength) {
-        return null;
-    }
-
-    const [dateSegment, timeSegment] = value.split(dateTimeSeparator);
-
-    if (!dateSegment || !timeSegment) {
+    if (timeSegment.length !== timeMode.length) {
         return null;
     }
 
     const date = maskitoParseDate(dateSegment, {mode: dateMode});
-
-    if (!date) {
-        return null;
-    }
-
     const time = maskitoParseTime(timeSegment, {mode: timeMode});
 
-    if (time === null || time === undefined) {
+    if (!date) {
         return null;
     }
 

--- a/projects/kit/src/lib/masks/date-time/utils/parse-date-time.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/parse-date-time.ts
@@ -1,0 +1,45 @@
+import {DEFAULT_MAX_DATE, DEFAULT_MIN_DATE} from '../../../constants';
+import {clamp} from '../../../utils';
+import {maskitoParseDate} from '../../date/utils';
+import {maskitoParseTime} from '../../time';
+import {DATE_TIME_SEPARATOR} from '../constants';
+import type {MaskitoDateTimeParams} from '../date-time-params';
+
+export function maskitoParseDateTime(
+    value: string,
+    {
+        dateMode,
+        timeMode,
+        min = DEFAULT_MIN_DATE,
+        max = DEFAULT_MAX_DATE,
+        dateTimeSeparator = DATE_TIME_SEPARATOR,
+    }: MaskitoDateTimeParams,
+): Date | null {
+    const modeLength = dateMode.length + dateTimeSeparator.length + timeMode.length;
+
+    if (value.length !== modeLength) {
+        return null;
+    }
+
+    const [dateSegment, timeSegment] = value.split(dateTimeSeparator);
+
+    if (!dateSegment || !timeSegment) {
+        return null;
+    }
+
+    const date = maskitoParseDate(dateSegment, {mode: dateMode});
+
+    if (!date) {
+        return null;
+    }
+
+    const time = maskitoParseTime(timeSegment, {mode: timeMode});
+
+    if (time === null || time === undefined) {
+        return null;
+    }
+
+    const dateTime = new Date(Number(date) + time);
+
+    return clamp(dateTime, min, max);
+}

--- a/projects/kit/src/lib/masks/date-time/utils/stringify-date-time.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/stringify-date-time.ts
@@ -24,15 +24,17 @@ export function maskitoStringifyDateTime(
         min,
         max,
     });
-    const timeString = maskitoStringifyTime(
-        validatedDate.getHours() * 3600000 +
-            validatedDate.getMinutes() * 60000 +
-            validatedDate.getSeconds() * 1000 +
-            validatedDate.getMilliseconds(),
-        {
-            mode: timeMode,
-        },
-    );
 
-    return `${dateString}${dateTimeSeparator}${timeString}`;
+    const extractedTime =
+        Number(validatedDate) -
+        Number(
+            new Date(
+                validatedDate.getFullYear(),
+                validatedDate.getMonth(),
+                validatedDate.getDate(),
+            ),
+        );
+    const timeString = maskitoStringifyTime(extractedTime, {mode: timeMode});
+
+    return dateString + dateTimeSeparator + timeString;
 }

--- a/projects/kit/src/lib/masks/date-time/utils/stringify-date-time.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/stringify-date-time.ts
@@ -1,0 +1,38 @@
+import {DEFAULT_MAX_DATE, DEFAULT_MIN_DATE} from '../../../constants';
+import {clamp} from '../../../utils';
+import {maskitoStringifyDate} from '../../date/utils';
+import {maskitoStringifyTime} from '../../time';
+import {DATE_TIME_SEPARATOR} from '../constants';
+import type {MaskitoDateTimeParams} from '../date-time-params';
+
+export function maskitoStringifyDateTime(
+    date: Date,
+    {
+        dateMode,
+        timeMode,
+        dateTimeSeparator = DATE_TIME_SEPARATOR,
+        dateSeparator = '.',
+        min = DEFAULT_MIN_DATE,
+        max = DEFAULT_MAX_DATE,
+    }: MaskitoDateTimeParams,
+): string {
+    const validatedDate = clamp(date, min, max);
+
+    const dateString = maskitoStringifyDate(validatedDate, {
+        mode: dateMode,
+        separator: dateSeparator,
+        min,
+        max,
+    });
+    const timeString = maskitoStringifyTime(
+        validatedDate.getHours() * 3600000 +
+            validatedDate.getMinutes() * 60000 +
+            validatedDate.getSeconds() * 1000 +
+            validatedDate.getMilliseconds(),
+        {
+            mode: timeMode,
+        },
+    );
+
+    return `${dateString}${dateTimeSeparator}${timeString}`;
+}

--- a/projects/kit/src/lib/masks/date-time/utils/tests/parse-date-time.spec.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/tests/parse-date-time.spec.ts
@@ -1,0 +1,169 @@
+import {DEFAULT_MAX_DATE, DEFAULT_MIN_DATE} from '../../../../constants';
+import {maskitoParseDateTime} from '../parse-date-time';
+
+describe('maskitoParseDateTime', () => {
+    const dateMode = 'dd/mm/yyyy';
+    const timeMode = 'HH:MM';
+    const dateTimeSeparator = ', ';
+
+    it('returns null for incomplete date-time string', () => {
+        expect(
+            maskitoParseDateTime('02/11/a2018', {dateMode, timeMode, dateTimeSeparator}),
+        ).toBeNull();
+        expect(
+            maskitoParseDateTime('16:20', {dateMode, timeMode, dateTimeSeparator}),
+        ).toBeNull();
+    });
+
+    it('parses valid date-time string', () => {
+        expect(
+            maskitoParseDateTime('02/11/2018, 16:20', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toEqual(new Date(2018, 10, 2, 16, 20));
+    });
+
+    it('clamps date-time to min and max bounds', () => {
+        const min = new Date(2020, 0, 1, 10, 1);
+        const max = new Date(2025, 11, 31, 11, 1);
+
+        expect(
+            maskitoParseDateTime('01/01/2019, 10:00', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+                min,
+                max,
+            }),
+        ).toEqual(min);
+
+        expect(
+            maskitoParseDateTime('01/01/2030, 10:00', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+                min,
+                max,
+            }),
+        ).toEqual(max);
+    });
+
+    it('handles default min and max bounds', () => {
+        expect(
+            maskitoParseDateTime('01/01/0001, 00:00', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toEqual(DEFAULT_MIN_DATE);
+
+        expect(
+            maskitoParseDateTime('31/12/9999, 00:00', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toEqual(DEFAULT_MAX_DATE);
+    });
+
+    it('parses date-time with custom separator', () => {
+        const customSeparator = 'T';
+
+        expect(
+            maskitoParseDateTime('02/11/2018T16:20', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator: customSeparator,
+            }),
+        ).toEqual(new Date(2018, 10, 2, 16, 20));
+    });
+
+    it('returns null for missing date-time separator', () => {
+        expect(
+            maskitoParseDateTime('02/11/201816:20', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toBeNull();
+    });
+
+    it('handles edge cases for leap years', () => {
+        expect(
+            maskitoParseDateTime('29/02/2020, 12:00', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toEqual(new Date(2020, 1, 29, 12, 0));
+        expect(
+            maskitoParseDateTime('29/02/2019, 12:00', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toEqual(new Date(2019, 2, 1, 12, 0));
+    });
+
+    it('handles edge cases for time boundaries', () => {
+        expect(
+            maskitoParseDateTime('31/12/2018, 00:00', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toEqual(new Date(2018, 11, 31, 0, 0));
+        expect(
+            maskitoParseDateTime('31/12/2018, 23:59', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toEqual(new Date(2018, 11, 31, 23, 59));
+    });
+
+    it('returns null for empty or whitespace-only input', () => {
+        expect(
+            maskitoParseDateTime('', {dateMode, timeMode, dateTimeSeparator}),
+        ).toBeNull();
+        expect(
+            maskitoParseDateTime('   ', {dateMode, timeMode, dateTimeSeparator}),
+        ).toBeNull();
+    });
+
+    it('handles invalid date-time separator', () => {
+        expect(
+            maskitoParseDateTime('31/12/2018-16:20', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toBeNull();
+        expect(
+            maskitoParseDateTime('31/12/2018 16:20', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toBeNull();
+    });
+
+    it('handles mixed valid and invalid inputs', () => {
+        expect(
+            maskitoParseDateTime('31/12/2018, invalid', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toBeNull();
+        expect(
+            maskitoParseDateTime('invalid, 16:20', {
+                dateMode,
+                timeMode,
+                dateTimeSeparator,
+            }),
+        ).toBeNull();
+    });
+});

--- a/projects/kit/src/lib/masks/date-time/utils/tests/parse-date-time.spec.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/tests/parse-date-time.spec.ts
@@ -8,7 +8,7 @@ describe('maskitoParseDateTime', () => {
 
     it('returns null for incomplete date-time string', () => {
         expect(
-            maskitoParseDateTime('02/11/a2018', {dateMode, timeMode, dateTimeSeparator}),
+            maskitoParseDateTime('02/11/2018', {dateMode, timeMode, dateTimeSeparator}),
         ).toBeNull();
         expect(
             maskitoParseDateTime('16:20', {dateMode, timeMode, dateTimeSeparator}),
@@ -60,9 +60,9 @@ describe('maskitoParseDateTime', () => {
         ).toEqual(DEFAULT_MIN_DATE);
 
         expect(
-            maskitoParseDateTime('31/12/9999, 00:00', {
+            maskitoParseDateTime('31/12/9999, 23:59:59.999', {
                 dateMode,
-                timeMode,
+                timeMode: 'HH:MM:SS.MSS',
                 dateTimeSeparator,
             }),
         ).toEqual(DEFAULT_MAX_DATE);

--- a/projects/kit/src/lib/masks/date-time/utils/tests/stringify-date-time.spec.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/tests/stringify-date-time.spec.ts
@@ -1,0 +1,86 @@
+import {maskitoStringifyDateTime} from '../stringify-date-time';
+
+describe('maskitoStringifyDateTime', () => {
+    const date = new Date(2025, 3, 11, 15, 30, 45);
+    const dateMode = 'dd/mm/yyyy';
+    const timeMode = 'HH:MM:SS';
+    const dateSeparator = '/';
+    const dateTimeSeparator = ', ';
+
+    it('should stringify date and time with default separator', () => {
+        const result = maskitoStringifyDateTime(date, {
+            dateMode,
+            timeMode,
+            dateSeparator,
+            dateTimeSeparator,
+        });
+
+        expect(result).toBe('11/04/2025, 15:30:45');
+    });
+
+    it('should stringify date and time with custom separator', () => {
+        const result = maskitoStringifyDateTime(date, {
+            dateMode,
+            timeMode,
+            dateSeparator,
+            dateTimeSeparator: ' | ',
+        });
+
+        expect(result).toBe('11/04/2025 | 15:30:45');
+    });
+
+    it('should clamp date to min boundary', () => {
+        const minDate = new Date('2025-04-12T00:00:00.000');
+        const result = maskitoStringifyDateTime(date, {
+            dateMode,
+            timeMode,
+            dateSeparator,
+            min: minDate,
+        });
+
+        expect(result).toBe('12/04/2025, 00:00:00');
+    });
+
+    it('should clamp date to max boundary', () => {
+        const maxDate = new Date('2025-04-10T23:59:59.999');
+        const result = maskitoStringifyDateTime(date, {
+            dateMode,
+            timeMode,
+            dateSeparator,
+            max: maxDate,
+        });
+
+        expect(result).toBe('10/04/2025, 23:59:59');
+    });
+
+    it('should handle edge cases for leap years', () => {
+        const leapYearDate = new Date('2024-02-29T12:00:00.000');
+        const result = maskitoStringifyDateTime(leapYearDate, {
+            dateMode,
+            timeMode,
+            dateSeparator,
+        });
+
+        expect(result).toBe('29/02/2024, 12:00:00');
+    });
+
+    it('should handle edge cases for time boundaries', () => {
+        const midnight = new Date('2025-04-11T00:00:00.000');
+        const resultMidnight = maskitoStringifyDateTime(midnight, {
+            dateMode,
+            timeMode,
+            dateSeparator,
+        });
+
+        expect(resultMidnight).toBe('11/04/2025, 00:00:00');
+
+        const endOfDay = new Date('2025-04-11T23:59:59.999');
+        const resultEndOfDay = maskitoStringifyDateTime(endOfDay, {
+            dateMode,
+            timeMode,
+            dateSeparator,
+        });
+
+        expect(resultEndOfDay).toBe('11/04/2025, 23:59:59');
+    });
+});


### PR DESCRIPTION
### Resume
add new `maskitoParseDateTime` and `maskitoStringifyDateTime` helpers

### Evidence
> Not required

### Reference
Closes https://github.com/taiga-family/maskito/issues/2002