### PR TITLE
chore: rename internal utility `parseDateTimeString` => `splitDateTimeString`

### DIFF
--- a/projects/kit/src/lib/masks/date-time/date-time-mask.ts
+++ b/projects/kit/src/lib/masks/date-time/date-time-mask.ts
@@ -26,7 +26,7 @@ import {DATE_TIME_SEPARATOR} from './constants';
 import type {MaskitoDateTimeParams} from './date-time-params';
 import {createMinMaxDateTimePostprocessor} from './postprocessors';
 import {createValidDateTimePreprocessor} from './preprocessors';
-import {parseDateTimeString} from './utils';
+import {splitDateTimeString} from './utils';
 
 export function maskitoDateTimeOptionsGenerator({
     dateMode,
@@ -80,7 +80,7 @@ export function maskitoDateTimeOptionsGenerator({
                 timeSegmentMinValues,
                 timeSegmentMaxValues,
                 parseValue: (x) => {
-                    const [dateString, timeString] = parseDateTimeString(
+                    const [dateString, timeString] = splitDateTimeString(
                         x,
                         dateModeTemplate,
                     );
@@ -102,7 +102,7 @@ export function maskitoDateTimeOptionsGenerator({
                 dateModeTemplate,
                 dateSegmentSeparator: dateSeparator,
                 splitFn: (value) => {
-                    const [dateString, timeString] = parseDateTimeString(
+                    const [dateString, timeString] = splitDateTimeString(
                         value,
                         dateModeTemplate,
                     );

--- a/projects/kit/src/lib/masks/date-time/postprocessors/min-max-date-time-postprocessor.ts
+++ b/projects/kit/src/lib/masks/date-time/postprocessors/min-max-date-time-postprocessor.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../utils';
 import {raiseSegmentValueToMin} from '../../../utils/date/raise-segment-value-to-min';
 import {parseTimeString} from '../../../utils/time';
-import {isDateTimeStringComplete, parseDateTimeString} from '../utils';
+import {isDateTimeStringComplete, splitDateTimeString} from '../utils';
 
 export function createMinMaxDateTimePostprocessor({
     dateModeTemplate,
@@ -28,7 +28,7 @@ export function createMinMaxDateTimePostprocessor({
     dateTimeSeparator: string;
 }): MaskitoPostprocessor {
     return ({value, selection}) => {
-        const [dateString, timeString] = parseDateTimeString(value, dateModeTemplate);
+        const [dateString, timeString] = splitDateTimeString(value, dateModeTemplate);
         const parsedDate = parseDateString(dateString, dateModeTemplate);
         const parsedTime = parseTimeString(timeString, timeMode);
 

--- a/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
+++ b/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
@@ -3,7 +3,7 @@ import type {MaskitoPreprocessor} from '@maskito/core';
 import type {MaskitoTimeMode, MaskitoTimeSegments} from '../../../types';
 import {validateDateString} from '../../../utils';
 import {enrichTimeSegmentsWithZeroes} from '../../../utils/time';
-import {parseDateTimeString} from '../utils';
+import {splitDateTimeString} from '../utils';
 
 export function createValidDateTimePreprocessor({
     dateModeTemplate,
@@ -38,7 +38,7 @@ export function createValidDateTimePreprocessor({
         let to = rawTo + data.length;
         const newPossibleValue = value.slice(0, from) + newCharacters + value.slice(to);
 
-        const [dateString, timeString] = parseDateTimeString(
+        const [dateString, timeString] = splitDateTimeString(
             newPossibleValue,
             dateModeTemplate,
         );

--- a/projects/kit/src/lib/masks/date-time/utils/index.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/index.ts
@@ -1,2 +1,2 @@
 export * from './is-date-time-string-complete';
-export * from './parse-date-time-string';
+export * from './split-date-time-string';

--- a/projects/kit/src/lib/masks/date-time/utils/split-date-time-string.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/split-date-time-string.ts
@@ -1,7 +1,7 @@
 const NON_DIGIT_PLACEHOLDER_RE = /[^dmy]/g;
 const LEADING_NON_DIGIT_RE = /^\D*/;
 
-export function parseDateTimeString(
+export function splitDateTimeString(
     dateTime: string,
     dateModeTemplate: string,
 ): [date: string, time: string] {

--- a/projects/kit/src/lib/masks/date-time/utils/tests/split-date-time-string.spec.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/tests/split-date-time-string.spec.ts
@@ -1,9 +1,9 @@
-import {parseDateTimeString} from '../parse-date-time-string';
+import {splitDateTimeString} from '../split-date-time-string';
 
-describe('parseDateTimeString', () => {
+describe('splitDateTimeString', () => {
     describe('dd.mm.yyyy', () => {
-        const parse = (value: string): [string, string] =>
-            parseDateTimeString(value, 'dd.mm.yyyy');
+        const split = (value: string): [string, string] =>
+            splitDateTimeString(value, 'dd.mm.yyyy');
 
         (
             [
@@ -28,14 +28,14 @@ describe('parseDateTimeString', () => {
             ] as const
         ).forEach(({input, output}) => {
             it(`${input} -> ${JSON.stringify(output)}`, () => {
-                expect(parse(input)).toEqual(output);
+                expect(split(input)).toEqual(output);
             });
         });
     });
 
     describe('dd. mm. yyyy (date segment separator consists of space and dot)', () => {
         const parse = (value: string): [string, string] =>
-            parseDateTimeString(value, 'dd. mm. yyyy');
+            splitDateTimeString(value, 'dd. mm. yyyy');
 
         (
             [


### PR DESCRIPTION
Internal utility
https://github.com/taiga-family/maskito/blob/5028084f9be876cf8b1dc2607956cd4906285c43/projects/kit/src/lib/masks/date-time/utils/parse-date-time-string.ts#L4-L7

can be confused with new public utility

https://github.com/taiga-family/maskito/blob/5028084f9be876cf8b1dc2607956cd4906285c43/projects/kit/src/lib/masks/date-time/utils/parse-date-time.ts#L8-L17

Rename it to `splitDateTimeString`.