### PR TITLE
fix(core): updated selection range (even if textfield value is untouched) should not be ignored

### DIFF
--- a/projects/demo-integrations/src/tests/kit/date-time/date-time-basic.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date-time/date-time-basic.cy.ts
@@ -351,6 +351,23 @@ describe('DateTime | Basic', () => {
                         .should('have.prop', 'selectionEnd', '01.01.2000, 2'.length);
                 },
             );
+
+            it(
+                '01.01.2000, 1|2|:30 => Press 5 => 01.01.2000, 15:|30',
+                BROWSER_SUPPORTS_REAL_EVENTS,
+                () => {
+                    cy.get('@input')
+                        .type('010120001230')
+                        .type('{leftArrow}'.repeat(':30'.length))
+                        .realPress(['Shift', 'ArrowLeft']);
+
+                    cy.get('@input')
+                        .type('5')
+                        .should('have.value', '01.01.2000, 15:30')
+                        .should('have.prop', 'selectionStart', '01.01.2000, 15:'.length)
+                        .should('have.prop', 'selectionEnd', '01.01.2000, 15:'.length);
+                },
+            );
         });
     });
 

--- a/projects/demo-integrations/src/tests/kit/time/time-basic.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/time/time-basic.cy.ts
@@ -312,6 +312,22 @@ describe('Time', () => {
                         .should('have.prop', 'selectionStart', '2'.length)
                         .should('have.prop', 'selectionEnd', '2'.length);
                 });
+
+                it('1|2|:34 => Press 9 => 19:|34', BROWSER_SUPPORTS_REAL_EVENTS, () => {
+                    cy.get('@input')
+                        .type('1234')
+                        .realPress([
+                            ...new Array(':34'.length).fill('ArrowLeft'),
+                            'Shift',
+                            'ArrowLeft',
+                        ]);
+
+                    cy.get('@input')
+                        .type('9')
+                        .should('have.value', '19:34')
+                        .should('have.prop', 'selectionStart', '19:'.length)
+                        .should('have.prop', 'selectionEnd', '19:'.length);
+                });
             });
         });
 


### PR DESCRIPTION
1. Open https://maskito.dev/kit/time/API
2. Paste
    ```
    00:00
    ```
3. Select the last digit in hour segment
    ```
    0|0|:00
    ```
4. Press `5`

**Expected**: `05:|00`
**Actual**: `05|:00`

Relates:
* https://github.com/taiga-family/taiga-ui/pull/10831