### PR TITLE
fix(kit): `Number` should support non-erasable minus (as `prefix`) for `max <= 0`

### DIFF
--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -89,11 +89,13 @@ export function maskitoNumberOptionsGenerator({
         mask: generateMaskExpression({
             decimalSeparator,
             maximumFractionDigits,
-            thousandSeparator,
-            prefix,
-            postfix,
-            isNegativeAllowed: min < 0,
+            min,
             minusSign,
+            postfix,
+            prefix,
+            pseudoMinuses,
+            thousandSeparator,
+            decimalPseudoSeparators: validatedDecimalPseudoSeparators,
         }),
         preprocessors: [
             createFullWidthToHalfWidthPreprocessor(),

--- a/projects/kit/src/lib/masks/number/processors/initialization-only-preprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/initialization-only-preprocessor.ts
@@ -2,6 +2,7 @@ import type {MaskitoPreprocessor} from '@maskito/core';
 import {maskitoTransform} from '@maskito/core';
 
 import {clamp, extractAffixes} from '../../../utils';
+import type {MaskitoNumberParams} from '../number-params';
 import {generateMaskExpression} from '../utils';
 
 /**
@@ -15,20 +16,16 @@ import {generateMaskExpression} from '../utils';
  * ```
  */
 export function createInitializationOnlyPreprocessor({
-    decimalSeparator,
     decimalPseudoSeparators,
-    pseudoMinuses,
-    prefix,
-    postfix,
+    decimalSeparator,
     minusSign,
-}: {
-    decimalSeparator: string;
-    decimalPseudoSeparators: readonly string[];
-    pseudoMinuses: readonly string[];
-    prefix: string;
-    postfix: string;
-    minusSign: string;
-}): MaskitoPreprocessor {
+    postfix,
+    prefix,
+    pseudoMinuses,
+}: Pick<
+    Required<MaskitoNumberParams>,
+    'decimalPseudoSeparators' | 'decimalSeparator' | 'minusSign' | 'postfix' | 'prefix'
+> & {pseudoMinuses: readonly string[]}): MaskitoPreprocessor {
     let isInitializationPhase = true;
     const cleanNumberMask = generateMaskExpression({
         decimalSeparator,
@@ -38,7 +35,7 @@ export function createInitializationOnlyPreprocessor({
         postfix: '',
         thousandSeparator: '',
         maximumFractionDigits: Infinity,
-        isNegativeAllowed: true,
+        min: Number.MIN_SAFE_INTEGER,
         minusSign,
     });
 

--- a/projects/kit/src/lib/masks/number/utils/generate-mask-expression.ts
+++ b/projects/kit/src/lib/masks/number/utils/generate-mask-expression.ts
@@ -1,33 +1,36 @@
 import type {MaskitoMask} from '@maskito/core';
 
 import {escapeRegExp} from '../../../utils';
+import type {MaskitoNumberParams} from '../number-params';
 
 export function generateMaskExpression({
+    decimalPseudoSeparators,
     decimalSeparator,
-    isNegativeAllowed,
     maximumFractionDigits,
-    thousandSeparator,
-    prefix,
-    postfix,
-    decimalPseudoSeparators = [],
-    pseudoMinuses = [],
+    min,
     minusSign,
-}: {
-    decimalSeparator: string;
-    isNegativeAllowed: boolean;
-    maximumFractionDigits: number;
-    thousandSeparator: string;
-    prefix: string;
-    postfix: string;
-    decimalPseudoSeparators?: readonly string[];
-    pseudoMinuses?: readonly string[];
-    minusSign: string;
-}): MaskitoMask {
-    const computedPrefix = computeAllOptionalCharsRegExp(prefix);
+    postfix,
+    prefix,
+    pseudoMinuses,
+    thousandSeparator,
+}: Pick<
+    Required<MaskitoNumberParams>,
+    | 'decimalPseudoSeparators'
+    | 'decimalSeparator'
+    | 'maximumFractionDigits'
+    | 'min'
+    | 'minusSign'
+    | 'postfix'
+    | 'prefix'
+    | 'thousandSeparator'
+> & {pseudoMinuses: readonly string[]}): MaskitoMask {
+    const computedPrefix =
+        min < 0 && [minusSign, ...pseudoMinuses].includes(prefix)
+            ? ''
+            : computeAllOptionalCharsRegExp(prefix);
     const digit = String.raw`\d`;
-    const optionalMinus = isNegativeAllowed
-        ? `[${minusSign}${pseudoMinuses.map((x) => `\\${x}`).join('')}]?`
-        : '';
+    const optionalMinus =
+        min < 0 ? `[${minusSign}${pseudoMinuses.map((x) => `\\${x}`).join('')}]?` : '';
     const integerPart = thousandSeparator
         ? `[${digit}${escapeRegExp(thousandSeparator).replaceAll(/\s/g, String.raw`\s`)}]*`
         : `[${digit}]*`;


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/taiga-ui/issues/10910
