### PR TITLE
feat(react): add support for React-specific `onChange` event handler

### DIFF
--- a/projects/demo-integrations/src/tests/component-testing/react/change-event/change-event.cy.tsx
+++ b/projects/demo-integrations/src/tests/component-testing/react/change-event/change-event.cy.tsx
@@ -1,0 +1,148 @@
+import type {MaskitoOptions} from '@maskito/core';
+import {maskitoNumberOptionsGenerator} from '@maskito/kit';
+import {useMaskito} from '@maskito/react';
+import {mount} from 'cypress/react';
+import type {ChangeEvent, JSX} from 'react';
+import {useCallback, useState} from 'react';
+
+describe('React synthetic "onChange" event', () => {
+    describe('uncontrolled input', () => {
+        beforeEach(() => {
+            const handler = cy.spy().as('handler');
+            const options = maskitoNumberOptionsGenerator({maximumFractionDigits: 2, thousandSeparator: ' '});
+
+            function App(): JSX.Element {
+                const maskRef = useMaskito({options});
+
+                return (
+                    <input
+                        ref={maskRef}
+                        onChange={(e) => handler(e.target.value)}
+                    />
+                );
+            }
+
+            mount(<App />);
+        });
+
+        it('type valid value (no mask interference) => onChange is dispatched', () => {
+            cy.get('input').type('0').should('have.value', '0');
+            cy.get('@handler').should('have.been.calledOnceWith', '0');
+        });
+
+        it('type invalid value (mask rejects it) => onChange is NOT dispatched', () => {
+            cy.get('input').type('t').should('have.value', '');
+            cy.get('@handler').should('not.have.been.called');
+        });
+
+        it('type partially valid value (mask corrects it and patch textfield) => onChange is dispatched ONCE', () => {
+            cy.get('input').type(',').should('have.value', '0.');
+            cy.get('@handler').should('have.been.calledOnceWith', '0.');
+        });
+
+        it('paste partially valid value (mask corrects it and patch textfield) => onChange is dispatched ONCE', () => {
+            cy.get('input').paste('123456,78').should('have.value', '123 456.78');
+            cy.get('@handler').should('have.been.calledOnceWith', '123 456.78');
+        });
+    });
+
+    describe('controlled input', () => {
+        beforeEach(() => {
+            const capitalize = (x: string): string => x.charAt(0).toUpperCase() + x.slice(1);
+            const handler = cy.spy().as('handler');
+            const options: MaskitoOptions = {
+                mask: /^[a-z]+$/i,
+                postprocessors: [({value, selection}) => ({value: value.replaceAll('t', 'T'), selection})],
+            };
+
+            function App(): JSX.Element {
+                const maskRef = useMaskito({options});
+                const [value, setValue] = useState('');
+                const onChange = useCallback(
+                    ({target: {value}}: ChangeEvent<HTMLInputElement>) => {
+                        handler(value);
+                        setValue(capitalize(value));
+                    },
+                    [setValue, handler],
+                );
+
+                return (
+                    <input
+                        ref={maskRef}
+                        value={value}
+                        onChange={onChange}
+                    />
+                );
+            }
+
+            mount(<App />);
+        });
+
+        it('type valid value (no mask interference) => onChange is dispatched', () => {
+            cy.get('input').type('N').should('have.value', 'N');
+            cy.get('@handler').should('have.been.calledOnceWith', 'N');
+            cy.get('input').type('i').should('have.value', 'Ni');
+            cy.get('@handler').should('have.been.calledWith', 'Ni');
+        });
+
+        it('type invalid value (mask rejects it) => onChange is NOT dispatched', () => {
+            cy.get('input').type('123').should('have.value', '');
+            cy.get('@handler').should('not.have.been.called');
+        });
+
+        it('type partially valid value (mask corrects it and patch textfield) => onChange is dispatched', () => {
+            cy.get('input').type('Nikit').should('have.value', 'NikiT');
+            cy.get('@handler').should('have.been.calledWith', 'NikiT');
+        });
+
+        it('type partially valid value (state action corrects it and patch textfield) => onChange is dispatched with initial value', () => {
+            cy.get('input').type('n').should('have.value', 'N');
+            cy.get('@handler').should('have.been.calledWith', 'n');
+        });
+
+        it('paste partially valid value (mask+state action correct it and patch textfield) => onChange is dispatched ONCE', () => {
+            cy.get('input').paste('nikita').should('have.value', 'NikiTa');
+            cy.get('@handler').should('have.been.calledOnceWith', 'nikiTa');
+        });
+    });
+
+    describe('controlled input with noop state handler', () => {
+        beforeEach(() => {
+            const handler = cy.spy().as('handler');
+            const options: MaskitoOptions = {
+                mask: /^[a-z]+$/i,
+                postprocessors: [({value, selection}) => ({value: value.toUpperCase(), selection})],
+            };
+
+            function App(): JSX.Element {
+                const maskRef = useMaskito({options});
+                const [value] = useState('');
+
+                return (
+                    <input
+                        ref={maskRef}
+                        value={value}
+                        onChange={(e) => handler(e.target.value)}
+                    />
+                );
+            }
+
+            mount(<App />);
+        });
+
+        it('type invalid value (mask rejects it) => onChange is NOT dispatched', () => {
+            cy.get('input').type('123').should('have.value', '');
+            cy.get('@handler').should('not.have.been.called');
+        });
+
+        it('type valid value (no mask interference) => textfield value is still empty', () => {
+            cy.get('input').type('T').should('have.value', '');
+            cy.get('@handler').should('have.been.calledWith', 'T');
+        });
+
+        it('type partially valid value (mask corrects it and patch textfield) => textfield value is still empty', () => {
+            cy.get('input').type('t').should('have.value', '');
+            cy.get('@handler').should('have.been.calledWith', 'T');
+        });
+    });
+});

--- a/projects/demo-integrations/src/tests/component-testing/react/change-event/change-event.cy.tsx
+++ b/projects/demo-integrations/src/tests/component-testing/react/change-event/change-event.cy.tsx
@@ -35,12 +35,12 @@ describe('React synthetic "onChange" event', () => {
             cy.get('@handler').should('not.have.been.called');
         });
 
-        it('type partially valid value (mask corrects it and patch textfield) => onChange is dispatched ONCE', () => {
+        it('type partially valid value (mask corrects it and patches textfield) => onChange is dispatched ONCE', () => {
             cy.get('input').type(',').should('have.value', '0.');
             cy.get('@handler').should('have.been.calledOnceWith', '0.');
         });
 
-        it('paste partially valid value (mask corrects it and patch textfield) => onChange is dispatched ONCE', () => {
+        it('paste partially valid value (mask corrects it and patches textfield) => onChange is dispatched ONCE', () => {
             cy.get('input').paste('123456,78').should('have.value', '123 456.78');
             cy.get('@handler').should('have.been.calledOnceWith', '123 456.78');
         });
@@ -90,17 +90,17 @@ describe('React synthetic "onChange" event', () => {
             cy.get('@handler').should('not.have.been.called');
         });
 
-        it('type partially valid value (mask corrects it and patch textfield) => onChange is dispatched', () => {
+        it('type partially valid value (mask corrects it and patches textfield) => onChange is dispatched', () => {
             cy.get('input').type('Nikit').should('have.value', 'NikiT');
             cy.get('@handler').should('have.been.calledWith', 'NikiT');
         });
 
-        it('type partially valid value (state action corrects it and patch textfield) => onChange is dispatched with initial value', () => {
+        it('type partially valid value (state action corrects it and patches textfield) => onChange is dispatched with initial value', () => {
             cy.get('input').type('n').should('have.value', 'N');
             cy.get('@handler').should('have.been.calledWith', 'n');
         });
 
-        it('paste partially valid value (mask+state action correct it and patch textfield) => onChange is dispatched ONCE', () => {
+        it('paste partially valid value (mask+state action correct it and patches textfield) => onChange is dispatched ONCE', () => {
             cy.get('input').paste('nikita').should('have.value', 'NikiTa');
             cy.get('@handler').should('have.been.calledOnceWith', 'nikiTa');
         });
@@ -140,7 +140,7 @@ describe('React synthetic "onChange" event', () => {
             cy.get('@handler').should('have.been.calledWith', 'T');
         });
 
-        it('type partially valid value (mask corrects it and patch textfield) => textfield value is still empty', () => {
+        it('type partially valid value (mask corrects it and patches textfield) => textfield value is still empty', () => {
             cy.get('input').type('t').should('have.value', '');
             cy.get('@handler').should('have.been.calledWith', 'T');
         });

--- a/projects/demo/src/pages/frameworks/react/react-doc.template.html
+++ b/projects/demo/src/pages/frameworks/react/react-doc.template.html
@@ -82,7 +82,7 @@
             <strong>Maskito</strong>
             too but usage of
             <code>onInput</code>
-            handler is more robust solution!
+            handler is a more robust solution!
         </tui-notification>
 
         <tui-doc-code [code]="controlledInputDemo" />

--- a/projects/demo/src/pages/frameworks/react/react-doc.template.html
+++ b/projects/demo/src/pages/frameworks/react/react-doc.template.html
@@ -55,11 +55,13 @@
         <p>
             <strong>Maskito</strong>
             core is developed as framework-agnostic library. It does not depend on any JS-framework's peculiarities. It
-            uses only native browser API. That is why you should use native
+            uses only native browser API. That is why we
+            <u>strongly recommends</u>
+            use native
             <code>onInput</code>
             instead of React-specific
             <code>onChange</code>
-            event. Do not worry, both events works similarly! Read more about it in the
+            event handler. Do not worry, both events works similarly! Read more about it in the
             <a
                 href="https://react.dev/reference/react-dom/components/input#props"
                 rel="noreferrer"
@@ -69,6 +71,19 @@
                 official React documentation.
             </a>
         </p>
+
+        <tui-notification
+            size="m"
+            class="tui-space_bottom-4"
+        >
+            React-specific
+            <code>onChange</code>
+            is supported by
+            <strong>Maskito</strong>
+            too but usage of
+            <code>onInput</code>
+            handler is more robust solution!
+        </tui-notification>
 
         <tui-doc-code [code]="controlledInputDemo" />
     </section>

--- a/projects/react/src/lib/adaptControlledElement.ts
+++ b/projects/react/src/lib/adaptControlledElement.ts
@@ -1,0 +1,58 @@
+import type {MaskitoElement} from '@maskito/core';
+
+/**
+ * React adds `_valueTracker` property to every textfield elements for its internal logic with controlled inputs.
+ * Also, React monkey-patches `value`-setter of the native textfield elements to update state inside its `_valueTracker`.
+ * @see https://github.com/facebook/react/blob/ee76351917106c6146745432a52e9a54a41ee181/packages/react-dom-bindings/src/client/inputValueTracking.js#L12-L19
+ */
+type ReactControlledElement = MaskitoElement & {
+    _valueTracker: {
+        getValue(): string;
+        setValue(value: string): void;
+        stopTracking(): void;
+    };
+};
+
+const isReactControlledElement = (
+    element: MaskitoElement,
+): element is ReactControlledElement => '_valueTracker' in element;
+
+export function adaptReactControlledElement(element: MaskitoElement): MaskitoElement {
+    if (!isReactControlledElement(element)) {
+        return element;
+    }
+
+    const adapter = {
+        set value(value: string) {
+            const lastValue = element._valueTracker.getValue();
+
+            element.value = value; // It will also update `_valueTracker` state
+            /**
+             * React depends on `_valueTracker` to know if the value was changed to decide:
+             * - should it revert state for controlled input (if its state handler does not update value)
+             * - should it dispatch its synthetic (not native!) `change` event
+             * ___
+             * When Maskito patches textfield with a valid value (using setter of `value` property),
+             * it also updates `_valueTracker` state and React mistakenly decides that nothing has happened.
+             * React should update `_valueTracker` state by itself.
+             * ___
+             * @see https://github.com/facebook/react/blob/ee76351917106c6146745432a52e9a54a41ee181/packages/react-dom-bindings/src/client/inputValueTracking.js#L173-L177
+             */
+            element._valueTracker.setValue(lastValue);
+        },
+    };
+
+    return new Proxy(element, {
+        get(target, prop: keyof HTMLElement) {
+            const nativeProperty = target[prop];
+
+            return typeof nativeProperty === 'function'
+                ? nativeProperty.bind(target)
+                : nativeProperty;
+        },
+        // eslint-disable-next-line @typescript-eslint/max-params
+        set(target, prop: keyof HTMLElement, val, receiver) {
+            return Reflect.set(prop in adapter ? adapter : target, prop, val, receiver);
+        },
+    });
+}

--- a/projects/react/src/lib/adaptControlledElement.ts
+++ b/projects/react/src/lib/adaptControlledElement.ts
@@ -4,41 +4,34 @@ import type {MaskitoElement} from '@maskito/core';
  * React adds `_valueTracker` property to every textfield elements for its internal logic with controlled inputs.
  * Also, React monkey-patches `value`-setter of the native textfield elements to update state inside its `_valueTracker`.
  * @see https://github.com/facebook/react/blob/ee76351917106c6146745432a52e9a54a41ee181/packages/react-dom-bindings/src/client/inputValueTracking.js#L12-L19
+ *
+ * React depends on `_valueTracker` to know if the value was changed to decide:
+ * - should it revert state for controlled input (if its state handler does not update value)
+ * - should it dispatch its synthetic (not native!) `change` event
+ *
+ * When Maskito patches textfield with a valid value (using setter of `value` property),
+ * it also updates `_valueTracker` state and React mistakenly decides that nothing has happened.
+ * React should update `_valueTracker` state by itself!
+ * ___
+ * @see https://github.com/facebook/react/blob/ee76351917106c6146745432a52e9a54a41ee181/packages/react-dom-bindings/src/client/inputValueTracking.js#L173-L177
  */
-type ReactControlledElement = MaskitoElement & {
-    _valueTracker: {
-        getValue(): string;
-        setValue(value: string): void;
-        stopTracking(): void;
-    };
-};
-
-const isReactControlledElement = (
-    element: MaskitoElement,
-): element is ReactControlledElement => '_valueTracker' in element;
-
 export function adaptReactControlledElement(element: MaskitoElement): MaskitoElement {
-    if (!isReactControlledElement(element)) {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+        getPrototype(element),
+        'value',
+    )?.set;
+
+    if (!valueSetter) {
         return element;
     }
 
     const adapter = {
         set value(value: string) {
-            const lastValue = element._valueTracker.getValue();
-
-            element.value = value; // It will also update `_valueTracker` state
             /**
-             * React depends on `_valueTracker` to know if the value was changed to decide:
-             * - should it revert state for controlled input (if its state handler does not update value)
-             * - should it dispatch its synthetic (not native!) `change` event
-             * ___
-             * When Maskito patches textfield with a valid value (using setter of `value` property),
-             * it also updates `_valueTracker` state and React mistakenly decides that nothing has happened.
-             * React should update `_valueTracker` state by itself.
-             * ___
-             * @see https://github.com/facebook/react/blob/ee76351917106c6146745432a52e9a54a41ee181/packages/react-dom-bindings/src/client/inputValueTracking.js#L173-L177
+             * Mimics exactly what happens when a browser silently changes the value property.
+             * Bypass the React monkey-patching.
              */
-            element._valueTracker.setValue(lastValue);
+            valueSetter.call(element, value);
         },
     };
 
@@ -55,4 +48,17 @@ export function adaptReactControlledElement(element: MaskitoElement): MaskitoEle
             return Reflect.set(prop in adapter ? adapter : target, prop, val, receiver);
         },
     });
+}
+
+function getPrototype(
+    element: MaskitoElement,
+): HTMLInputElement | HTMLTextAreaElement | null | undefined {
+    switch (element.nodeName) {
+        case 'INPUT':
+            return globalThis.HTMLInputElement?.prototype;
+        case 'TEXTAREA':
+            return globalThis.HTMLTextAreaElement?.prototype;
+        default:
+            return null;
+    }
 }

--- a/projects/react/src/lib/tests/controlledInput.spec.tsx
+++ b/projects/react/src/lib/tests/controlledInput.spec.tsx
@@ -5,10 +5,6 @@ import {render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useCallback, useState} from 'react';
 
-const options: MaskitoOptions = {
-    mask: /^[a-z]$/i,
-};
-
 describe('Maskito with React controlled input', () => {
     let testElement: RenderResult;
 
@@ -16,26 +12,30 @@ describe('Maskito with React controlled input', () => {
         user.type(testElement.getByRole('textbox'), v);
     const getValue = (): string => (testElement.getByRole('textbox') as HTMLInputElement).value;
 
+    function TestComponent({handler, options}: Readonly<{handler?: Function; options: MaskitoOptions}>): JSX.Element {
+        const inputRef = useMaskito({options});
+        const [value, setValue] = useState('');
+
+        return (
+            <input
+                ref={inputRef}
+                value={value}
+                onInput={(e) => {
+                    const value = (e.target as HTMLInputElement).value;
+
+                    return handler ? handler(value) : setValue(value);
+                }}
+            />
+        );
+    }
+
     describe('works with basic mask without processors (only mask expression)', () => {
-        function TestComponent({handler}: Readonly<{handler?: Function}>): JSX.Element {
-            const inputRef = useMaskito({options});
-            const [value, setValue] = useState('');
-
-            return (
-                <input
-                    ref={inputRef}
-                    value={value}
-                    onInput={(e) => {
-                        const value = (e.target as HTMLInputElement).value;
-
-                        return handler ? handler(value) : setValue(value);
-                    }}
-                />
-            );
-        }
+        const options: MaskitoOptions = {
+            mask: /^[a-z]$/i,
+        };
 
         it('updates value for setState-like action', async () => {
-            testElement = render(<TestComponent />);
+            testElement = render(<TestComponent options={options} />);
 
             const user = userEvent.setup();
 
@@ -48,7 +48,12 @@ describe('Maskito with React controlled input', () => {
         it('does not update value for noop handler of onInput event', async () => {
             const noop = (): void => {};
 
-            testElement = render(<TestComponent handler={noop} />);
+            testElement = render(
+                <TestComponent
+                    handler={noop}
+                    options={options}
+                />,
+            );
 
             const user = userEvent.setup();
 
@@ -61,7 +66,12 @@ describe('Maskito with React controlled input', () => {
         it('triggers onInput handler on every valid input', async () => {
             const handler = jest.fn();
 
-            testElement = render(<TestComponent handler={handler} />);
+            testElement = render(
+                <TestComponent
+                    handler={handler}
+                    options={options}
+                />,
+            );
 
             const user = userEvent.setup();
 
@@ -95,6 +105,83 @@ describe('Maskito with React controlled input', () => {
 
             await setValue(user, 't');
             expect(getValue()).toBe('T');
+        });
+    });
+
+    describe('works with complex mask with processors', () => {
+        const options: MaskitoOptions = {
+            mask: /^[a-z]$/i,
+            postprocessors: [({value, selection}) => ({selection, value: value.toUpperCase()})],
+        };
+
+        it('updates value for setState-like action', async () => {
+            testElement = render(<TestComponent options={options} />);
+
+            const user = userEvent.setup();
+
+            await setValue(user, '1'); // invalid character
+            expect(getValue()).toBe('');
+            await setValue(user, 't'); // valid character
+            expect(getValue()).toBe('T');
+        });
+
+        it('does not update value for noop handler of onInput event', async () => {
+            const noop = (): void => {};
+
+            testElement = render(
+                <TestComponent
+                    handler={noop}
+                    options={options}
+                />,
+            );
+
+            const user = userEvent.setup();
+
+            await setValue(user, '1'); // invalid character
+            expect(getValue()).toBe('');
+            await setValue(user, 't'); // valid character
+            expect(getValue()).toBe('');
+        });
+
+        it('triggers onInput handler on every valid input', async () => {
+            const handler = jest.fn();
+
+            testElement = render(
+                <TestComponent
+                    handler={handler}
+                    options={options}
+                />,
+            );
+
+            const user = userEvent.setup();
+
+            await setValue(user, '1'); // invalid character
+            expect(handler).not.toHaveBeenCalled();
+            await setValue(user, 't'); // valid character
+            expect(handler).toHaveBeenCalledWith('T');
+        });
+
+        it('state-handler can modify element value', async () => {
+            function App(): JSX.Element {
+                const inputRef = useMaskito({options});
+                const [value, setValue] = useState('');
+                const onInputHandler = useCallback(({value}: HTMLInputElement) => setValue(`###${value}`), [setValue]);
+
+                return (
+                    <input
+                        ref={inputRef}
+                        value={value}
+                        onInput={(e) => onInputHandler(e.target as HTMLInputElement)}
+                    />
+                );
+            }
+
+            testElement = render(<App />);
+
+            const user = userEvent.setup();
+
+            await setValue(user, 't');
+            expect(getValue()).toBe('###T');
         });
     });
 

--- a/projects/react/src/lib/useMaskito.ts
+++ b/projects/react/src/lib/useMaskito.ts
@@ -7,6 +7,7 @@ import {Maskito, MASKITO_DEFAULT_ELEMENT_PREDICATE} from '@maskito/core';
 import type {RefCallback} from 'react';
 import {useCallback, useRef, useState} from 'react';
 
+import {adaptReactControlledElement} from './adaptControlledElement';
 import {useIsomorphicLayoutEffect} from './useIsomorphicLayoutEffect';
 
 function isThenable<T = unknown>(x: PromiseLike<T> | T): x is PromiseLike<T> {
@@ -76,7 +77,7 @@ export const useMaskito = ({
             return;
         }
 
-        const maskedElement = new Maskito(element, options);
+        const maskedElement = new Maskito(adaptReactControlledElement(element), options);
 
         return () => {
             maskedElement.destroy();


### PR DESCRIPTION
This PR solves 2 problems


## Problem 1
```jsx
const options: MaskitoOptions = {
    mask: /^[a-z]+$/i,
    postprocessors: [({value, selection}) => ({selection, value: value.toUpperCase()})],
};

function App() {
    const inputRef = useMaskito({options});
    const [value, neverCalledFn] = useState('');

    return (
        <input
            ref={inputRef}
            value={value}
            onInput={(e) => console.log(e.target.value)}
        />
    );
}
```

**Expected behavior:** textfield value is always empty
**Actual behavior:** textfield value is updated on every keystroke

Learn more: https://react.dev/reference/react-dom/components/input#controlling-an-input-with-a-state-variable

<br />


## Problem 2
```jsx
const options: MaskitoOptions = {
    mask: /^[a-z]+$/i,
    postprocessors: [({value, selection}) => ({selection, value: value.toUpperCase()})],
};

function App() {
    const inputRef = useMaskito({options});

    return (
        <input
            ref={inputRef}
            onChange={(e) => console.log(e.target.value)}
        />
    );
}
```

**Expected behavior:** `onChange` event is never be emitted, no console logs. 
**Actual behavior:** `onChange` event is emitted on every keystroke

Learn more: https://maskito.dev/frameworks/react#controlled-input

___

## Possible solutions

1. Inspired by https://github.com/facebook/react/issues/11488#issuecomment-347775628

<details>
<summary>Working solution via <code>_valueTracker</code> property </summary>

```ts
import type {MaskitoElement} from '@maskito/core';

/**
 * React adds `_valueTracker` property to every textfield elements for its internal logic with controlled inputs.
 * Also, React monkey-patches `value`-setter of the native textfield elements to update state inside its `_valueTracker`.
 * @see https://github.com/facebook/react/blob/ee76351917106c6146745432a52e9a54a41ee181/packages/react-dom-bindings/src/client/inputValueTracking.js#L12-L19
 */
type ReactControlledElement = MaskitoElement & {
    _valueTracker: {
        getValue(): string;
        setValue(value: string): void;
        stopTracking(): void;
    };
};

const isReactControlledElement = (
    element: MaskitoElement,
): element is ReactControlledElement => '_valueTracker' in element;

export function adaptReactControlledElement(element: MaskitoElement): MaskitoElement {
    if (!isReactControlledElement(element)) {
        return element;
    }

    const adapter = {
        set value(value: string) {
            const lastValue = element._valueTracker.getValue();

            element.value = value; // It will also update `_valueTracker` state
            /**
             * React depends on `_valueTracker` to know if the value was changed to decide:
             * - should it revert state for controlled input (if its state handler does not update value)
             * - should it dispatch its synthetic (not native!) `change` event
             * ___
             * When Maskito patches textfield with a valid value (using setter of `value` property),
             * it also updates `_valueTracker` state and React mistakenly decides that nothing has happened.
             * React should update `_valueTracker` state by itself.
             * ___
             * @see https://github.com/facebook/react/blob/ee76351917106c6146745432a52e9a54a41ee181/packages/react-dom-bindings/src/client/inputValueTracking.js#L173-L177
             */
            element._valueTracker.setValue(lastValue);
        },
    };

    return new Proxy(element, {
        get(target, prop: keyof HTMLElement) {
            const nativeProperty = target[prop];

            return typeof nativeProperty === 'function'
                ? nativeProperty.bind(target)
                : nativeProperty;
        },
        set(target, prop: keyof HTMLElement, val, receiver) {
            return Reflect.set(prop in adapter ? adapter : target, prop, val, receiver);
        },
    });
}

```
</details>


2. Cypress solution (see this [comment](https://github.com/cypress-io/cypress/issues/647#issuecomment-335829482) and [this PR](https://github.com/cypress-io/cypress/pull/732/files#diff-53b7d619fa4613db14158a57ca69e8170a6f5e3d2271c61e762c801bff15552dR33-R40)):

> My idea is this - when we go to change the .value= of an input, we first check to see if that property has been overwritten using Object.getOwnPropertyDescriptor. If we reset it to
HTMLInputElement.prototype.value or even just call the setter function directly with the input as context, then react will not be notified of the value change. That'll end up setting the value and bypass the overridden method - which mimics exactly what happens when a browser silently changes the value property.

This solution was introduced in Cypress@1.0.2 and [still exists in Cypress@14](https://github.com/cypress-io/cypress/blob/a0a4eb1b2c1baac9f4d6ad4b02a3db44b4abd70b/packages/driver/src/dom/elements/nativeProps.ts#L42-L44).

This PR chooses Cypress-way to solve this same issue.
