### PR TITLE
ci: compatibility with `eslint-plugin-jest@28.13.0`

### DIFF
--- a/projects/core/src/lib/classes/mask-model/tests/mask-model-fixed-characters.spec.ts
+++ b/projects/core/src/lib/classes/mask-model/tests/mask-model-fixed-characters.spec.ts
@@ -30,6 +30,7 @@ describe('MaskModel | Fixed characters', () => {
             ],
         };
 
+        /* eslint-disable jest/prefer-ending-with-an-expect */
         const check = ({
             initialValue,
             addedCharacters,

--- a/projects/core/src/lib/utils/test/pipe.spec.ts
+++ b/projects/core/src/lib/utils/test/pipe.spec.ts
@@ -173,6 +173,7 @@ describe('maskitoPipe', () => {
     describe('Readonly arguments are passed to all processors', () => {
         const elementState: ElementState = {value: '', selection: [0, 0]};
 
+        /* eslint-disable jest/prefer-ending-with-an-expect */
         it('preprocessor', () => {
             const checkActionType: MaskitoPreprocessor = (data, actionType) => {
                 expect(actionType).toBe('deleteBackward');

--- a/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
@@ -100,18 +100,20 @@ describe('toNumberParts', () => {
         });
     });
 
-    it('different minus signs', () => {
+    describe('different minus signs', () => {
         [CHAR_MINUS, CHAR_HYPHEN, CHAR_EN_DASH, CHAR_EM_DASH, CHAR_JP_HYPHEN].forEach(
             (minus) => {
-                expect(
-                    toNumberParts(`${minus}1,234,567.89`, {
-                        decimalSeparator: '.',
-                        minusSign: minus,
-                    }),
-                ).toEqual({
-                    minus,
-                    integerPart: '1,234,567',
-                    decimalPart: '89',
+                it('minus', () => {
+                    expect(
+                        toNumberParts(`${minus}1,234,567.89`, {
+                            decimalSeparator: '.',
+                            minusSign: minus,
+                        }),
+                    ).toEqual({
+                        minus,
+                        integerPart: '1,234,567',
+                        decimalPart: '89',
+                    });
                 });
             },
         );

--- a/projects/kit/src/lib/processors/tests/normalize-date-preprocessor.spec.ts
+++ b/projects/kit/src/lib/processors/tests/normalize-date-preprocessor.spec.ts
@@ -11,6 +11,7 @@ describe('normalizeDatePreprocessor', () => {
             rangeSeparator: ' – ',
         });
 
+        /* eslint-disable jest/prefer-ending-with-an-expect */
         const check = getCheckFunction(preprocessor);
 
         it('empty input => 6.2.2023 – 7.2.2023', () => {

--- a/projects/kit/src/lib/processors/tests/valid-date-preprocessor.spec.ts
+++ b/projects/kit/src/lib/processors/tests/valid-date-preprocessor.spec.ts
@@ -11,6 +11,7 @@ describe('createValidDatePreprocessor', () => {
         });
         const EMPTY_INPUT = {value: '', selection: [0, 0] as [number, number]};
 
+        /* eslint-disable jest/prefer-ending-with-an-expect */
         const check = (insertedCharacters: string, expectedValue: string): void => {
             const {data} = preprocessor(
                 {elementState: EMPTY_INPUT, data: insertedCharacters},

--- a/projects/kit/src/lib/processors/tests/with-placeholder.spec.ts
+++ b/projects/kit/src/lib/processors/tests/with-placeholder.spec.ts
@@ -12,6 +12,7 @@ describe('maskitoWithPlaceholder("dd/mm/yyyy")', () => {
     };
 
     describe('preprocessors', () => {
+        /* eslint-disable jest/prefer-ending-with-an-expect */
         const check = (valueBefore: string, valueAfter: string): void => {
             const {elementState} = preprocessor(
                 {


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/maskito/pull/2158

```json
"node_modules/eslint-plugin-jest": {
            "version": "28.13.0",
```


```
/projects/core/src/lib/classes/mask-model/tests/mask-model-fixed-characters.spec.ts
Error:    65:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    73:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    81:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
[...]

/projects/core/src/lib/utils/test/pipe.spec.ts
Error:   176:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   189:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect

/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
Error:   103:5  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect

/projects/kit/src/lib/processors/tests/normalize-date-preprocessor.spec.ts
Error:    16:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    20:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    24:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
[...]

/projects/kit/src/lib/processors/tests/valid-date-preprocessor.spec.ts
Error:   23:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   27:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   31:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
[...]

/home/runner/work/maskito/maskito/projects/kit/src/lib/processors/tests/with-placeholder.spec.ts
Error:   30:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   32:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   34:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
[...]

✖ 48 problems (48 errors, 0 warnings)
```
