### PR TITLE
fix(core): Android with Microsoft SwiftKey Keyboard ignores `preventDefault()` for `beforeinput` event on backspace

### DIFF
--- a/projects/core/src/lib/plugins/broken-prevent-default.plugin.ts
+++ b/projects/core/src/lib/plugins/broken-prevent-default.plugin.ts
@@ -1,0 +1,50 @@
+import type {MaskitoPlugin} from '@maskito/core';
+
+import type {TypedInputEvent} from '../types';
+import {EventListener} from '../utils';
+
+/**
+ * All `input` events with `inputType=deleteContentBackward` always follows `beforeinput` event with the same `inputType`.
+ * If `beforeinput[inputType=deleteContentBackward]` is prevented, subsequent `input[inputType=deleteContentBackward]` is prevented too.
+ * There is an exception – Android devices with Microsoft SwiftKey Keyboard in Mobile Chrome.
+ * These devices ignores `preventDefault` for `beforeinput` event if Backspace is pressed.
+ * @see https://github.com/taiga-family/maskito/issues/2135#issuecomment-2980729647
+ * ___
+ * TODO: track Chromium bug report and delete this plugin after bug fix
+ * https://issues.chromium.org/issues/40885402
+ */
+export function createBrokenDefaultPlugin(): MaskitoPlugin {
+    return (element) => {
+        const eventListener = new EventListener(element);
+
+        let isVirtualAndroidKeyboard = false;
+        let beforeinputEvent: TypedInputEvent;
+        let value = element.value;
+
+        eventListener.listen('keydown', ({key}) => {
+            isVirtualAndroidKeyboard = key === 'Unidentified';
+        });
+
+        eventListener.listen('beforeinput', (event) => {
+            beforeinputEvent = event;
+            value = element.value;
+        });
+
+        eventListener.listen(
+            'input',
+            (event) => {
+                if (
+                    isVirtualAndroidKeyboard &&
+                    beforeinputEvent.defaultPrevented &&
+                    beforeinputEvent.inputType === 'deleteContentBackward' &&
+                    event.inputType === 'deleteContentBackward'
+                ) {
+                    element.value = value;
+                }
+            },
+            {capture: true},
+        );
+
+        return () => eventListener.destroy();
+    };
+}

--- a/projects/core/src/lib/plugins/index.ts
+++ b/projects/core/src/lib/plugins/index.ts
@@ -1,3 +1,4 @@
+export * from './broken-prevent-default.plugin';
 export * from './change-event-plugin';
 export * from './double-space.plugin';
 export * from './initial-calibration-plugin';


### PR DESCRIPTION
Fixes #2135

Relates https://issues.chromium.org/issues/40885402