### PR TITLE
chore: deprecate safari hack

### DIFF
--- a/projects/demo/src/pages/documentation/real-world-form/index.ts
+++ b/projects/demo/src/pages/documentation/real-world-form/index.ts
@@ -100,6 +100,7 @@ export default class RealWorldForm {
         return maskitoGetCountryFromNumber(this.form.value.phone ?? '', metadata) ?? '';
     }
 
+    // TODO: delete after bumping Safari support to 18+
     protected get phoneTextfieldPattern(): string {
         return this.isApple ? '+[0-9-]{1,20}' : '';
     }

--- a/projects/demo/src/pages/phone/phone-doc.component.ts
+++ b/projects/demo/src/pages/phone/phone-doc.component.ts
@@ -112,6 +112,7 @@ export default class PhoneDocComponent implements GeneratorOptions {
         return metadataSets[this.selectedMetadata];
     }
 
+    // TODO: delete after bumping Safari support to 18+
     protected get pattern(): string {
         return this.isApple ? '+[0-9-]{1,20}' : '';
     }


### PR DESCRIPTION
## IOS 16
Hack with pattern works

https://github.com/user-attachments/assets/52f93d87-c637-45c7-b18c-1a51d2b87019


## IOS 17
Hack is not working

https://github.com/user-attachments/assets/9241778f-f0d8-4190-850c-7f0177b54d80



## IOS 18
Hack is not required

https://github.com/user-attachments/assets/5d83336a-8e07-4691-800c-04b45d95375d



___

<details>
<summary>Source code</summary>

```html
<form>
    <input
        autocomplete="tel"
        inputmode="tel"
        placeholder="Without pattern='+[0-9-]{1,20}'"
        style="font-size: 23px;width: 100%;"
    />

    <input
        autocomplete="tel"
        inputmode="tel"
        pattern="+[0-9-]{1,20}"
        placeholder="With pattern='+[0-9-]{1,20}'"
        style="font-size: 23px;width: 100%;"
    />
</form>

<p id="logs"></p>

<script>
    const inputs = document.querySelectorAll('input');

    inputs.forEach(input => {
        input.addEventListener('beforeinput', log);
        input.addEventListener('input', log);
    });

    function log(e) {
        document.querySelector('#logs').innerHTML += '<br />' + JSON.stringify({
            type: e.type,
            inputType: e.inputType,
            data: e.data, 
            value: e.target.value, 
            selectionStart: e.target.selectionStart, 
            selectionEnd: e.target.selectionEnd
        }, null, 2);
    }
</script>
```
</details>
