### PR TITLE
fix(kit): date-related mask with month-first mode has incorrect zero-padding logic

### DIFF
--- a/projects/demo-integrations/src/tests/kit/date-range/date-range-segments-zero-padding.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date-range/date-range-segments-zero-padding.cy.ts
@@ -52,6 +52,35 @@ describe('DateRange | Date segments zero padding (pads digits with zero if date 
         });
     });
 
+    describe('[mode]="mm/dd/yyyy"', () => {
+        const mode = encodeURIComponent('mm/dd/yyyy');
+        const dateSeparator = encodeURIComponent('/');
+        const FIRST_DATE = '01/01/2000';
+
+        beforeEach(() => {
+            cy.visit(
+                `/${DemoPath.DateRange}/API?mode=${mode}&dateSeparator=${dateSeparator}&rangeSeparator=-`,
+            );
+            cy.get('#demo-content input')
+                .should('be.visible')
+                .first()
+                .focus()
+                .type('01012000')
+                .should('have.value', FIRST_DATE)
+                .as('input');
+        });
+
+        describe('handles month value exceeding maximum', () => {
+            it('{firstDate} => Type 13 => {firstDate}-01/3', () => {
+                cy.get('@input')
+                    .type('13')
+                    .should('have.value', `${FIRST_DATE}-01/3`)
+                    .should('have.prop', 'selectionStart', `${FIRST_DATE}-01/3`.length)
+                    .should('have.prop', 'selectionEnd', `${FIRST_DATE}-01/3`.length);
+            });
+        });
+    });
+
     describe('[mode]="yyyy/mm/dd"', () => {
         const mode = encodeURIComponent('yyyy/mm/dd');
         const dateSeparator = encodeURIComponent('/');

--- a/projects/demo-integrations/src/tests/kit/date/date-segments-zero-padding.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date/date-segments-zero-padding.cy.ts
@@ -130,6 +130,27 @@ describe('Date | Date segments zero padding (pads digits with zero if date segme
         });
     });
 
+    describe('[mode]="mm/dd/yyyy"', () => {
+        beforeEach(() => {
+            cy.visit(`/${DemoPath.Date}/API?mode=mm%2Fdd%2Fyyyy&separator=/`);
+            cy.get('#demo-content input')
+                .should('be.visible')
+                .first()
+                .focus()
+                .as('input');
+        });
+
+        describe('handles month value exceeding maximum', () => {
+            it('Type 13 => 01/3', () => {
+                cy.get('@input')
+                    .type('13')
+                    .should('have.value', '01/3')
+                    .should('have.prop', 'selectionStart', '01/3'.length)
+                    .should('have.prop', 'selectionEnd', '01/3'.length);
+            });
+        });
+    });
+
     describe('[mode]="yyyy/mm/dd"', () => {
         beforeEach(() => {
             cy.visit(

--- a/projects/kit/src/lib/utils/date/validate-date-string.ts
+++ b/projects/kit/src/lib/utils/date/validate-date-string.ts
@@ -50,7 +50,7 @@ export function validateDateString({
                 return {validatedDateString: '', updatedSelection: [from, to]}; // prevent changes
             }
 
-            validatedDateSegments[segmentName] = `0${segmentValue[0]}`;
+            validatedDateSegments[segmentName] = `0${segmentValue.slice(0, -1)}`;
             dateSegments[i + 1] = [
                 nextSegment,
                 segmentValue.slice(-1) + (dateSegments[i + 1]?.[1] ?? '').slice(1),

--- a/projects/kit/src/lib/utils/date/validate-date-string.ts
+++ b/projects/kit/src/lib/utils/date/validate-date-string.ts
@@ -50,8 +50,7 @@ export function validateDateString({
                 return {validatedDateString: '', updatedSelection: [from, to]}; // prevent changes
             }
 
-            validatedDateSegments[segmentName] =
-                `0${segmentValue.slice(0, lastSegmentDigitIndex)}`;
+            validatedDateSegments[segmentName] = `0${segmentValue[0]}`;
             dateSegments[i + 1] = [
                 nextSegment,
                 segmentValue.slice(-1) + (dateSegments[i + 1]?.[1] ?? '').slice(1),


### PR DESCRIPTION
### Summary
Fixed incorrect padding behavior logic and added corresponding tests to ensure proper functionality.
### Reference
Fixes #2141 
