### PR TITLE
ci: compatibility with `eslint-plugin-jest@28.13.0`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,16 @@ module.exports = {
                 'no-irregular-whitespace': 'off',
             },
         },
+        {
+            files: ['*.spec.ts'],
+            rules: {
+                'jest/prefer-ending-with-an-expect': [
+                    'error',
+                    {
+                        assertFunctionNames: ['expect', 'check'],
+                    },
+                ],
+            },
+        },
     ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -22601,9 +22601,9 @@
             }
         },
         "node_modules/eslint-plugin-jest": {
-            "version": "28.12.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.12.0.tgz",
-            "integrity": "sha512-J6zmDp8WiQ9tyvYXE+3RFy7/+l4hraWLzmsabYXyehkmmDd36qV4VQFc7XzcsD8C1PTNt646MSx25bO1mdd9Yw==",
+            "version": "28.14.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.14.0.tgz",
+            "integrity": "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -49223,7 +49223,7 @@
             "peerDependencies": {
                 "@angular/core": ">=16.0.0",
                 "@angular/forms": ">=16.0.0",
-                "@maskito/core": "^3.9.0"
+                "@maskito/core": "^3.9.1"
             }
         },
         "projects/core": {
@@ -49243,9 +49243,9 @@
                 "@angular/platform-browser-dynamic": "16.2.12",
                 "@angular/platform-server": "16.2.12",
                 "@angular/router": "16.2.12",
-                "@maskito/angular": "^3.9.1",
-                "@maskito/core": "^3.9.1",
-                "@maskito/kit": "^3.9.1",
+                "@maskito/angular": "*",
+                "@maskito/core": "*",
+                "@maskito/kit": "*",
                 "@ng-web-apis/common": "4.12.0",
                 "@ng-web-apis/universal": "4.12.0",
                 "@nguniversal/builders": "16.2.0",
@@ -49284,7 +49284,7 @@
             "version": "3.9.1",
             "license": "Apache-2.0",
             "peerDependencies": {
-                "@maskito/core": "^3.9.0"
+                "@maskito/core": "^3.9.1"
             }
         },
         "projects/phone": {
@@ -49295,8 +49295,8 @@
                 "libphonenumber-js": "1.12.9"
             },
             "peerDependencies": {
-                "@maskito/core": "^3.9.0",
-                "@maskito/kit": "^3.9.0",
+                "@maskito/core": "^3.9.1",
+                "@maskito/kit": "^3.9.1",
                 "libphonenumber-js": ">=1.0.0"
             }
         },
@@ -49314,7 +49314,7 @@
                 "react-test-renderer": "18.3.1"
             },
             "peerDependencies": {
-                "@maskito/core": "^3.9.0",
+                "@maskito/core": "^3.9.1",
                 "react": ">=16.8",
                 "react-dom": ">=16.8"
             }
@@ -49329,7 +49329,7 @@
                 "vue": "3.5.16"
             },
             "peerDependencies": {
-                "@maskito/core": "^3.9.0",
+                "@maskito/core": "^3.9.1",
                 "vue": ">=3.0.0"
             }
         }

--- a/projects/core/src/lib/utils/test/pipe.spec.ts
+++ b/projects/core/src/lib/utils/test/pipe.spec.ts
@@ -173,6 +173,7 @@ describe('maskitoPipe', () => {
     describe('Readonly arguments are passed to all processors', () => {
         const elementState: ElementState = {value: '', selection: [0, 0]};
 
+        // eslint-disable-next-line jest/prefer-ending-with-an-expect
         it('preprocessor', () => {
             const checkActionType: MaskitoPreprocessor = (data, actionType) => {
                 expect(actionType).toBe('deleteBackward');
@@ -186,6 +187,7 @@ describe('maskitoPipe', () => {
             );
         });
 
+        // eslint-disable-next-line jest/prefer-ending-with-an-expect
         it('postprocessor', () => {
             const initialElementState: ElementState = {
                 value: '27',

--- a/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
@@ -100,18 +100,20 @@ describe('toNumberParts', () => {
         });
     });
 
-    it('different minus signs', () => {
+    describe('different minus signs', () => {
         [CHAR_MINUS, CHAR_HYPHEN, CHAR_EN_DASH, CHAR_EM_DASH, CHAR_JP_HYPHEN].forEach(
             (minus) => {
-                expect(
-                    toNumberParts(`${minus}1,234,567.89`, {
-                        decimalSeparator: '.',
-                        minusSign: minus,
-                    }),
-                ).toEqual({
-                    minus,
-                    integerPart: '1,234,567',
-                    decimalPart: '89',
+                it(`${minus}`, () => {
+                    expect(
+                        toNumberParts(`${minus}1,234,567.89`, {
+                            decimalSeparator: '.',
+                            minusSign: minus,
+                        }),
+                    ).toEqual({
+                        minus,
+                        integerPart: '1,234,567',
+                        decimalPart: '89',
+                    });
                 });
             },
         );


### PR DESCRIPTION
Relates:
* https://github.com/taiga-family/maskito/pull/2159

```
> eslint . --fix


/home/runner/work/maskito/maskito/projects/core/src/lib/classes/mask-model/tests/mask-model-fixed-characters.spec.ts
Error:    65:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    73:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    81:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    89:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    97:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   105:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect

/home/runner/work/maskito/maskito/projects/core/src/lib/utils/test/pipe.spec.ts
Error:   176:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   189:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect

/home/runner/work/maskito/maskito/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
Error:   103:5  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect

/home/runner/work/maskito/maskito/projects/kit/src/lib/processors/tests/normalize-date-preprocessor.spec.ts
Error:    16:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    20:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    24:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    28:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    32:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    45:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    49:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    53:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    66:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    70:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    74:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    86:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    90:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    94:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:    98:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   102:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   106:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect

/home/runner/work/maskito/maskito/projects/kit/src/lib/processors/tests/valid-date-preprocessor.spec.ts
Error:   23:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   27:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   31:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   35:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   39:9  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect

/home/runner/work/maskito/maskito/projects/kit/src/lib/processors/tests/with-placeholder.spec.ts
Error:   30:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   32:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   34:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   36:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   38:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   40:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   42:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   44:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   46:9   error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   75:21  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   77:21  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   79:21  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   81:21  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   83:21  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   85:21  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   87:21  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
Error:   89:21  error  Tests should end with an assertion  jest/prefer-ending-with-an-expect
```