### PR TITLE
chore: remove `overrides` for `highlight.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,9 +128,6 @@
         "prepend": true,
         "template": "templates/note.hbs"
     },
-    "overrides": {
-        "highlight.js": "11.11.1"
-    },
     "syncer": {
         "includePaths": [
             "./projects",


### PR DESCRIPTION
Library `highlight.js` fixed its bug with JSX.
This `overrides` is no more required

Explore body of this PR for more details:
* https://github.com/taiga-family/maskito/pull/738