### PR TITLE
fix(core): do not insert fixed character on attempt to enter invalid character at its position

### DIFF
--- a/projects/core/src/lib/classes/mask-model/mask-model.ts
+++ b/projects/core/src/lib/classes/mask-model/mask-model.ts
@@ -55,16 +55,18 @@ export class MaskModel implements ElementState {
             maskExpression,
             initialElementState,
         );
+        const prevLeadingPart = value.slice(0, from);
+        const newLeadingValuePart = calibrateValueByMask(
+            {
+                value: newUnmaskedLeadingValuePart,
+                selection: [newCaretIndex, newCaretIndex],
+            },
+            maskExpression,
+            initialElementState,
+        ).value;
         const isInvalidCharsInsertion =
-            value.slice(0, from) ===
-            calibrateValueByMask(
-                {
-                    value: newUnmaskedLeadingValuePart,
-                    selection: [newCaretIndex, newCaretIndex],
-                },
-                maskExpression,
-                initialElementState,
-            ).value;
+            prevLeadingPart === newLeadingValuePart ||
+            newLeadingValuePart.length < prevLeadingPart.length;
 
         if (
             isInvalidCharsInsertion ||

--- a/projects/core/src/lib/classes/mask-model/tests/mask-model-fixed-characters.spec.ts
+++ b/projects/core/src/lib/classes/mask-model/tests/mask-model-fixed-characters.spec.ts
@@ -150,4 +150,24 @@ describe('MaskModel | Fixed characters', () => {
             });
         });
     });
+
+    it('attempt to enter invalid character at the position of fixed character', () => {
+        const dateMask: Required<MaskitoOptions> = {
+            ...MASKITO_DEFAULT_OPTIONS,
+            mask: [/\d/, /\d/, '.', /\d/, /\d/],
+        };
+
+        const selection = [2, 2] as const;
+        const maskModel = new MaskModel(
+            {
+                selection,
+                value: '12',
+            },
+            dateMask,
+        );
+
+        expect(() => maskModel.addCharacters(selection, '#')).toThrow();
+        expect(maskModel.value).toBe('12');
+        expect(maskModel.selection).toEqual(selection);
+    });
 });

--- a/projects/core/src/lib/classes/mask-model/utils/guess-valid-value-by-pattern.ts
+++ b/projects/core/src/lib/classes/mask-model/utils/guess-valid-value-by-pattern.ts
@@ -34,9 +34,13 @@ export function guessValidValueByPattern(
                 return newValidatedChars + charConstraint;
             }
 
-            return char.match(charConstraint)
-                ? newValidatedChars + char
-                : newValidatedChars;
+            if (char.match(charConstraint)) {
+                return newValidatedChars + char;
+            }
+
+            return leadingCharacters.startsWith(char)
+                ? newValidatedChars
+                : validatedCharacters;
         },
         '',
     );

--- a/projects/demo-integrations/src/tests/kit/date-time/date-time-meridiem.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date-time/date-time-meridiem.cy.ts
@@ -38,7 +38,7 @@ describe('DateTime | time modes with meridiem', () => {
                     .should('have.prop', 'selectionEnd', '01.01.2000, 12:34 AM'.length);
             });
 
-            it('<any date>12:34| => Type lowercase `p` => <any date>12:34 AM', () => {
+            it('<any date>12:34| => Type lowercase `p` => <any date>12:34 PM', () => {
                 cy.get('@textfield')
                     .type('01.01.20001234p')
                     .should('have.value', '01.01.2000, 12:34 PM')
@@ -46,7 +46,7 @@ describe('DateTime | time modes with meridiem', () => {
                     .should('have.prop', 'selectionEnd', '01.01.2000, 12:34 PM'.length);
             });
 
-            it('<any date>12:34| => Type uppercase `P` => <any date>12:34 AM', () => {
+            it('<any date>12:34| => Type uppercase `P` => <any date>12:34 PM', () => {
                 cy.get('@textfield')
                     .type('01.01.20001234P')
                     .should('have.value', '01.01.2000, 12:34 PM')
@@ -54,20 +54,20 @@ describe('DateTime | time modes with meridiem', () => {
                     .should('have.prop', 'selectionEnd', '01.01.2000, 12:34 PM'.length);
             });
 
-            it('<any date>12:34| => Type lowercase `m` => <any date>12:34', () => {
+            it('<any date>12:34| => Type lowercase `m` => <any date>12:34|', () => {
                 cy.get('@textfield')
                     .type('01.01.20001234m')
-                    .should('have.value', '01.01.2000, 12:34 ')
-                    .should('have.prop', 'selectionStart', '01.01.2000, 12:34 '.length)
-                    .should('have.prop', 'selectionEnd', '01.01.2000, 12:34 '.length);
+                    .should('have.value', '01.01.2000, 12:34')
+                    .should('have.prop', 'selectionStart', '01.01.2000, 12:34'.length)
+                    .should('have.prop', 'selectionEnd', '01.01.2000, 12:34'.length);
             });
 
-            it('<any date>12:34| => Type uppercase `M` => <any date>12:34', () => {
+            it('<any date>12:34| => Type uppercase `M` => <any date>12:34|', () => {
                 cy.get('@textfield')
                     .type('01.01.20001234M')
-                    .should('have.value', '01.01.2000, 12:34 ')
-                    .should('have.prop', 'selectionStart', '01.01.2000, 12:34 '.length)
-                    .should('have.prop', 'selectionEnd', '01.01.2000, 12:34 '.length);
+                    .should('have.value', '01.01.2000, 12:34')
+                    .should('have.prop', 'selectionStart', '01.01.2000, 12:34'.length)
+                    .should('have.prop', 'selectionEnd', '01.01.2000, 12:34'.length);
             });
         });
 
@@ -272,7 +272,7 @@ describe('DateTime | time modes with meridiem', () => {
 
                 beforeEach(() => {
                     cy.get('@textfield')
-                        .type('01.01.2000 1234 ')
+                        .type('01.01.2000 1234 ')
                         .should('have.value', beforeMeridiemValue);
                 });
 

--- a/projects/demo-integrations/src/tests/kit/date-time/date-time-separator.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date-time/date-time-separator.cy.ts
@@ -17,8 +17,8 @@ describe('DateTime | Separator', () => {
 
         it('rejects dot as separator', () => {
             cy.get('@input')
-                .type('1412.')
-                .should('have.value', '14/12/')
+                .type('1412')
+                .should('have.value', '14/12')
                 .type('2000')
                 .should('have.value', '14/12/2000');
         });
@@ -56,8 +56,8 @@ describe('DateTime | Separator', () => {
             cy.get('@input')
                 .type('14')
                 .should('have.value', '14')
-                .type('12.')
-                .should('have.value', '14-12-');
+                .type('12')
+                .should('have.value', '14-12');
         });
     });
 });

--- a/projects/demo-integrations/src/tests/kit/date-time/date-time-time-step.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date-time/date-time-time-step.cy.ts
@@ -15,7 +15,7 @@ describe('DateTime | timeStep', () => {
                     .as('input');
 
                 cy.get('@input')
-                    .type('2212.')
+                    .type('2212;')
                     .should('have.value', '22.12;')
                     .should('have.a.prop', 'selectionStart', '22.12;'.length)
                     .should('have.a.prop', 'selectionEnd', '22.12;'.length);

--- a/projects/demo-integrations/src/tests/kit/time/time-meridiem.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/time/time-meridiem.cy.ts
@@ -57,17 +57,17 @@ describe('Time | modes with meridiem', () => {
             it('12:34| => Type lowercase `m` => 12:34', () => {
                 cy.get('@textfield')
                     .type('1234m')
-                    .should('have.value', '12:34 ')
-                    .should('have.prop', 'selectionStart', '12:34 '.length)
-                    .should('have.prop', 'selectionEnd', '12:34 '.length);
+                    .should('have.value', '12:34')
+                    .should('have.prop', 'selectionStart', '12:34'.length)
+                    .should('have.prop', 'selectionEnd', '12:34'.length);
             });
 
             it('12:34| => Type uppercase `M` => 12:34', () => {
                 cy.get('@textfield')
                     .type('1234M')
-                    .should('have.value', '12:34 ')
-                    .should('have.prop', 'selectionStart', '12:34 '.length)
-                    .should('have.prop', 'selectionEnd', '12:34 '.length);
+                    .should('have.value', '12:34')
+                    .should('have.prop', 'selectionStart', '12:34'.length)
+                    .should('have.prop', 'selectionEnd', '12:34'.length);
             });
         });
 
@@ -283,7 +283,7 @@ describe('Time | modes with meridiem', () => {
         describe('toggle meridiem value on ArrowUp / ArrowDown', () => {
             describe('Initial value === "12:34 |"', () => {
                 beforeEach(() => {
-                    cy.get('@textfield').type('1234 ');
+                    cy.get('@textfield').type('1234 ');
                 });
 
                 it('↑ --- 12:34 |AM', () => {


### PR DESCRIPTION
```ts
const dateMask: MaskitoOptions = {
    mask: [/\d/, /\d/, '.', /\d/, /\d/],
};
```

Textfield contains `12` and caret is placed after the last digit.
```
12| => Type # => ???
```

Actual behavior: `12.`
Expected behavior: `12`