### PR TITLE
chore: fix size of Maskito logo in root `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![All packages CI](https://github.com/taiga-family/maskito/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/taiga-family/maskito/actions/workflows/build.yml)
 
 <p align="center">
-    <img src="projects/demo/src/assets/icons/maskito.svg" alt="Maskito logo" height="120px">
+    <img src="projects/demo/src/assets/icons/maskito.svg" alt="Maskito logo" width="120px">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Problem
<img width="804" height="357" alt="before" src="https://github.com/user-attachments/assets/12d564fb-ec3b-4f28-8bc1-1d4089082d64" />
