### PR TITLE
fix(kit): `DateRange` + `minLength` / `maxLength` has incorrect limits

### DIFF
--- a/projects/kit/src/lib/masks/date-range/constants.ts
+++ b/projects/kit/src/lib/masks/date-range/constants.ts
@@ -13,3 +13,22 @@ export const POSSIBLE_DATE_RANGE_SEPARATOR = [
     CHAR_MINUS,
     CHAR_JP_HYPHEN,
 ];
+
+export const MIN_DAY = 1;
+
+export const MONTHS_IN_YEAR = 12;
+
+export const MonthNumber = {
+    January: 0,
+    February: 1,
+    March: 2,
+    April: 3,
+    May: 4,
+    June: 5,
+    July: 6,
+    August: 7,
+    September: 8,
+    October: 9,
+    November: 10,
+    December: 11,
+} as const;

--- a/projects/kit/src/lib/masks/date-range/processors/min-max-range-length-postprocessor.ts
+++ b/projects/kit/src/lib/masks/date-range/processors/min-max-range-length-postprocessor.ts
@@ -50,17 +50,9 @@ export function createMinMaxRangeLengthPostprocessor({
             return {value, selection};
         }
 
-        const minDistantToDate = appendDate(fromDate, {
-            ...minLength,
-            // 06.02.2023 - 07.02.2023 => {minLength: {day: 3}} => 06.02.2023 - 08.02.2023
-            // "from"-day is included in the range
-            day: minLength?.day && minLength.day - 1,
-        });
+        const minDistantToDate = appendDate(fromDate, minLength);
         const maxDistantToDate = !isEmpty(maxLength)
-            ? appendDate(fromDate, {
-                  ...maxLength,
-                  day: maxLength?.day && maxLength.day - 1, // "from"-day is included in the range
-              })
+            ? appendDate(fromDate, maxLength)
             : max;
 
         const minLengthClampedToDate = clamp(toDate, minDistantToDate, max);

--- a/projects/kit/src/lib/utils/date/append-date.ts
+++ b/projects/kit/src/lib/utils/date/append-date.ts
@@ -40,7 +40,9 @@ export function appendDate(
         days += getMonthDaysCount(months, isLeapYear(years));
     }
 
-    return new Date(years, months, days - 1); // "from"-day is included in the range
+    days = day >= 0 ? days - 1 : days + 1; // "from"-day is included in the range
+
+    return new Date(years, months, days);
 }
 
 function getMonthDaysCount(month: number, isLeapYear: boolean): number {

--- a/projects/kit/src/lib/utils/date/append-date.ts
+++ b/projects/kit/src/lib/utils/date/append-date.ts
@@ -40,7 +40,10 @@ export function appendDate(
         days += getMonthDaysCount(months, isLeapYear(years));
     }
 
-    days = day >= 0 ? days - 1 : days + 1; // "from"-day is included in the range
+    days =
+        day < 0 || (day === 0 && isLeapYear(initialYear) && (month < 0 || year < 0))
+            ? days + 1 // add one day when moving days backward, or months or years backward for leap year
+            : days - 1; // "from"-day is included in the range
 
     return new Date(years, months, days);
 }

--- a/projects/kit/src/lib/utils/date/append-date.ts
+++ b/projects/kit/src/lib/utils/date/append-date.ts
@@ -1,22 +1,62 @@
+import {MIN_DAY, MonthNumber, MONTHS_IN_YEAR} from '../../masks/date-range/constants';
 import type {MaskitoDateSegments} from '../../types';
 
 export function appendDate(
-    initialDate: Date,
-    {day, month, year}: Partial<MaskitoDateSegments<number>> = {},
+    date: Date,
+    {day = 0, month = 0, year = 0}: Partial<MaskitoDateSegments<number>> = {},
 ): Date {
-    const date = new Date(initialDate);
-
-    if (day) {
-        date.setDate(date.getDate() + day);
+    if (day === 0 && month === 0 && year === 0) {
+        return date;
     }
 
-    if (month) {
-        date.setMonth(date.getMonth() + month);
+    const initialYear = date.getFullYear();
+    const initialMonth = date.getMonth();
+    const initialDate = date.getDate();
+
+    const totalMonths = (initialYear + year) * MONTHS_IN_YEAR + initialMonth + month;
+    let years = Math.floor(totalMonths / MONTHS_IN_YEAR);
+    let months = totalMonths % MONTHS_IN_YEAR;
+    let days = Math.min(initialDate, getMonthDaysCount(months, isLeapYear(years))) + day;
+
+    while (days > getMonthDaysCount(months, isLeapYear(years))) {
+        days -= getMonthDaysCount(months, isLeapYear(years));
+
+        if (months === MonthNumber.December) {
+            years++;
+            months = MonthNumber.January;
+        } else {
+            months++;
+        }
     }
 
-    if (year) {
-        date.setFullYear(date.getFullYear() + year);
+    while (days < MIN_DAY) {
+        if (months === MonthNumber.January) {
+            years--;
+            months = MonthNumber.December;
+        } else {
+            months--;
+        }
+
+        days += getMonthDaysCount(months, isLeapYear(years));
     }
 
-    return date;
+    return new Date(years, months, days - 1); // "from"-day is included in the range
+}
+
+function getMonthDaysCount(month: number, isLeapYear: boolean): number {
+    switch (month) {
+        case MonthNumber.April:
+        case MonthNumber.June:
+        case MonthNumber.November:
+        case MonthNumber.September:
+            return 30;
+        case MonthNumber.February:
+            return isLeapYear ? 29 : 28;
+        default:
+            return 31;
+    }
+}
+
+function isLeapYear(year: number): boolean {
+    return year % 400 === 0 || (year % 4 === 0 && year % 100 !== 0);
 }

--- a/projects/kit/src/lib/utils/date/tests/append-date.spec.ts
+++ b/projects/kit/src/lib/utils/date/tests/append-date.spec.ts
@@ -49,12 +49,12 @@ describe('appendDate', () => {
         expect(result.getDate()).toBe(14);
     });
 
-    it('year: 1995, month: 6, day: 14, if {year: -5} was passed', () => {
+    it('year: 1995, month: 6, day: 16, if {year: -5} was passed', () => {
         const result = appendDate(y2000m6d15, {year: -5});
 
         expect(result.getFullYear()).toBe(1995);
         expect(result.getMonth()).toBe(6);
-        expect(result.getDate()).toBe(14);
+        expect(result.getDate()).toBe(16);
     });
 
     it('year: 2000, month: 11, day: 14, if {month: 5} was passed', () => {
@@ -65,12 +65,12 @@ describe('appendDate', () => {
         expect(result.getDate()).toBe(14);
     });
 
-    it('year: 2000, month: 1, day: 14, if {month: -5} was passed', () => {
+    it('year: 2000, month: 1, day: 16, if {month: -5} was passed', () => {
         const result = appendDate(y2000m6d15, {month: -5});
 
         expect(result.getFullYear()).toBe(2000);
         expect(result.getMonth()).toBe(1);
-        expect(result.getDate()).toBe(14);
+        expect(result.getDate()).toBe(16);
     });
 
     it('year: 2000, month: 6, day: 19, if {day: 5} was passed', () => {
@@ -81,7 +81,7 @@ describe('appendDate', () => {
         expect(result.getDate()).toBe(19);
     });
 
-    it('year: 2000, month: 6, day: 9, if {day: -5} was passed', () => {
+    it('year: 2000, month: 6, day: 11, if {day: -5} was passed', () => {
         const result = appendDate(y2000m6d15, {day: -5});
 
         expect(result.getFullYear()).toBe(2000);
@@ -113,7 +113,7 @@ describe('appendDate', () => {
         expect(result.getDate()).toBe(31);
     });
 
-    it('year: 1999, month: 11, day: 30, if {day: -197} was passed', () => {
+    it('year: 2000, month: 0, day: 1, if {day: -197} was passed', () => {
         const result = appendDate(y2000m6d15, {day: -197});
 
         expect(result.getFullYear()).toBe(2000);
@@ -121,7 +121,7 @@ describe('appendDate', () => {
         expect(result.getDate()).toBe(1);
     });
 
-    it('year: 2000, month: 5, day: 29, if {day: -15} was passed', () => {
+    it('year: 2000, month: 6, day: 1, if {day: -15} was passed', () => {
         const result = appendDate(y2000m6d15, {day: -15});
 
         expect(result.getFullYear()).toBe(2000);
@@ -137,7 +137,7 @@ describe('appendDate', () => {
         expect(result.getDate()).toBe(28);
     });
 
-    it('year: 1999, month: 11, day: 30, if {month: -6, day: -15} was passed', () => {
+    it('year: 2000, month: 0, day: 1, if {month: -6, day: -15} was passed', () => {
         const result = appendDate(y2000m6d15, {month: -6, day: -15});
 
         expect(result.getFullYear()).toBe(2000);
@@ -145,7 +145,15 @@ describe('appendDate', () => {
         expect(result.getDate()).toBe(1);
     });
 
-    it('capped day when moving forward', () => {
+    it('year: 1999, month: 0, day: 1, if {month: -6, day: -15, year: -1} was passed', () => {
+        const result = appendDate(y2000m6d15, {month: -6, day: -15, year: -1});
+
+        expect(result.getFullYear()).toBe(1999);
+        expect(result.getMonth()).toBe(0);
+        expect(result.getDate()).toBe(1);
+    });
+
+    it('capped day when moving month backward', () => {
         const result = appendDate(new Date(2018, 2, 30), {
             month: -1,
         });
@@ -155,7 +163,7 @@ describe('appendDate', () => {
         expect(result.getDate()).toBe(27);
     });
 
-    it('capped day when moving backward', () => {
+    it('capped day when moving month forward', () => {
         const result = appendDate(new Date(2018, 0, 31), {month: 1});
 
         expect(result.getFullYear()).toBe(2018);

--- a/projects/kit/src/lib/utils/date/tests/append-date.spec.ts
+++ b/projects/kit/src/lib/utils/date/tests/append-date.spec.ts
@@ -86,7 +86,7 @@ describe('appendDate', () => {
 
         expect(result.getFullYear()).toBe(2000);
         expect(result.getMonth()).toBe(6);
-        expect(result.getDate()).toBe(9);
+        expect(result.getDate()).toBe(11);
     });
 
     it('year: 2000, month: 6, day: 31, if {day: 17} was passed', () => {
@@ -116,17 +116,17 @@ describe('appendDate', () => {
     it('year: 1999, month: 11, day: 30, if {day: -197} was passed', () => {
         const result = appendDate(y2000m6d15, {day: -197});
 
-        expect(result.getFullYear()).toBe(1999);
-        expect(result.getMonth()).toBe(11);
-        expect(result.getDate()).toBe(30);
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(0);
+        expect(result.getDate()).toBe(1);
     });
 
     it('year: 2000, month: 5, day: 29, if {day: -15} was passed', () => {
         const result = appendDate(y2000m6d15, {day: -15});
 
         expect(result.getFullYear()).toBe(2000);
-        expect(result.getMonth()).toBe(5);
-        expect(result.getDate()).toBe(29);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(1);
     });
 
     it('year: 2000, month: 2, day: 28, if {month: -4, day: 14} was passed', () => {
@@ -140,9 +140,9 @@ describe('appendDate', () => {
     it('year: 1999, month: 11, day: 30, if {month: -6, day: -15} was passed', () => {
         const result = appendDate(y2000m6d15, {month: -6, day: -15});
 
-        expect(result.getFullYear()).toBe(1999);
-        expect(result.getMonth()).toBe(11);
-        expect(result.getDate()).toBe(30);
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(0);
+        expect(result.getDate()).toBe(1);
     });
 
     it('capped day when moving forward', () => {

--- a/projects/kit/src/lib/utils/date/tests/append-date.spec.ts
+++ b/projects/kit/src/lib/utils/date/tests/append-date.spec.ts
@@ -1,0 +1,181 @@
+import {describe, expect, it} from '@jest/globals';
+
+import {appendDate} from '../append-date';
+
+const y2000m6d15 = new Date(2000, 6, 15);
+
+describe('appendDate', () => {
+    it('year: 2000, month: 6, day: 15, if {} was passed', () => {
+        const result = appendDate(y2000m6d15, {});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(15);
+    });
+
+    it('year: 2000, month: 6, day: 15, if {year: 0} was passed', () => {
+        const result = appendDate(y2000m6d15, {year: 0});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(15);
+    });
+
+    it('year: 2000, month: 6, day: 15, if {year: 0, month: 0} was passed', () => {
+        const result = appendDate(y2000m6d15, {year: 0, month: 0});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(15);
+    });
+
+    it('year: 2000, month: 6, day: 15, if {year: 0, month: 0, day: 0} was passed', () => {
+        const result = appendDate(y2000m6d15, {
+            year: 0,
+            month: 0,
+            day: 0,
+        });
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(15);
+    });
+
+    it('year: 2005, month: 6, day: 14, if {year: 5} was passed', () => {
+        const result = appendDate(y2000m6d15, {year: 5});
+
+        expect(result.getFullYear()).toBe(2005);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(14);
+    });
+
+    it('year: 1995, month: 6, day: 14, if {year: -5} was passed', () => {
+        const result = appendDate(y2000m6d15, {year: -5});
+
+        expect(result.getFullYear()).toBe(1995);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(14);
+    });
+
+    it('year: 2000, month: 11, day: 14, if {month: 5} was passed', () => {
+        const result = appendDate(y2000m6d15, {month: 5});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(11);
+        expect(result.getDate()).toBe(14);
+    });
+
+    it('year: 2000, month: 1, day: 14, if {month: -5} was passed', () => {
+        const result = appendDate(y2000m6d15, {month: -5});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(1);
+        expect(result.getDate()).toBe(14);
+    });
+
+    it('year: 2000, month: 6, day: 19, if {day: 5} was passed', () => {
+        const result = appendDate(y2000m6d15, {day: 5});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(19);
+    });
+
+    it('year: 2000, month: 6, day: 9, if {day: -5} was passed', () => {
+        const result = appendDate(y2000m6d15, {day: -5});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(9);
+    });
+
+    it('year: 2000, month: 6, day: 31, if {day: 17} was passed', () => {
+        const result = appendDate(y2000m6d15, {day: 17});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(6);
+        expect(result.getDate()).toBe(31);
+    });
+
+    it('year: 2000, month: 11, day: 30, if {day: 169} was passed', () => {
+        const result = appendDate(y2000m6d15, {day: 169});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(11);
+        expect(result.getDate()).toBe(30);
+    });
+
+    it('year: 2000, month: 11, day: 31, if {day: 170} was passed', () => {
+        const result = appendDate(y2000m6d15, {day: 170});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(11);
+        expect(result.getDate()).toBe(31);
+    });
+
+    it('year: 1999, month: 11, day: 30, if {day: -197} was passed', () => {
+        const result = appendDate(y2000m6d15, {day: -197});
+
+        expect(result.getFullYear()).toBe(1999);
+        expect(result.getMonth()).toBe(11);
+        expect(result.getDate()).toBe(30);
+    });
+
+    it('year: 2000, month: 5, day: 29, if {day: -15} was passed', () => {
+        const result = appendDate(y2000m6d15, {day: -15});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(5);
+        expect(result.getDate()).toBe(29);
+    });
+
+    it('year: 2000, month: 2, day: 28, if {month: -4, day: 14} was passed', () => {
+        const result = appendDate(y2000m6d15, {month: -4, day: 14});
+
+        expect(result.getFullYear()).toBe(2000);
+        expect(result.getMonth()).toBe(2);
+        expect(result.getDate()).toBe(28);
+    });
+
+    it('year: 1999, month: 11, day: 30, if {month: -6, day: -15} was passed', () => {
+        const result = appendDate(y2000m6d15, {month: -6, day: -15});
+
+        expect(result.getFullYear()).toBe(1999);
+        expect(result.getMonth()).toBe(11);
+        expect(result.getDate()).toBe(30);
+    });
+
+    it('capped day when moving forward', () => {
+        const result = appendDate(new Date(2018, 2, 30), {
+            month: -1,
+        });
+
+        expect(result.getFullYear()).toBe(2018);
+        expect(result.getMonth()).toBe(1);
+        expect(result.getDate()).toBe(27);
+    });
+
+    it('capped day when moving backward', () => {
+        const result = appendDate(new Date(2018, 0, 31), {month: 1});
+
+        expect(result.getFullYear()).toBe(2018);
+        expect(result.getMonth()).toBe(1);
+        expect(result.getDate()).toBe(27);
+    });
+
+    it('year: 2025, month: 0, day: 31, if {month: 1} was passed', () => {
+        const result = appendDate(new Date(2025, 0, 1), {month: 1});
+
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(0);
+        expect(result.getDate()).toBe(31);
+    });
+
+    it('year: 2025, month: 1, day: 27, if {month: 1} was passed', () => {
+        const result = appendDate(new Date(2025, 0, 31), {month: 1});
+
+        expect(result.getFullYear()).toBe(2025);
+        expect(result.getMonth()).toBe(1);
+        expect(result.getDate()).toBe(27);
+    });
+});


### PR DESCRIPTION
Fixes #1884 
