### PR TITLE
fix(kit): `Number` with `input[maxlength]` is incompatible with `document.execCommand('delete')`

### DIFF
--- a/projects/demo-integrations/src/tests/component-testing/utils.ts
+++ b/projects/demo-integrations/src/tests/component-testing/utils.ts
@@ -11,6 +11,7 @@ import {MASKITO_DEFAULT_ELEMENT_PREDICATE} from '@maskito/core';
 
 @Component({
     standalone: true,
+    selector: 'test-input',
     imports: [MaskitoDirective],
     template: `
         <input


### PR DESCRIPTION
Fixes #2215
