### PR TITLE
fix(kit): `maskitoStringifyNumber` fails to stringify number with exponential notation

### DIFF
--- a/projects/kit/src/lib/masks/number/utils/stringify-number.ts
+++ b/projects/kit/src/lib/masks/number/utils/stringify-number.ts
@@ -3,6 +3,7 @@ import {maskitoTransform} from '@maskito/core';
 import {clamp} from '../../../utils';
 import {maskitoNumberOptionsGenerator} from '../number-mask';
 import type {MaskitoNumberParams} from '../number-params';
+import {stringifyNumberWithoutExp} from './stringify-number-without-exp';
 
 export function maskitoStringifyNumber(
     number: number,
@@ -18,7 +19,10 @@ export function maskitoStringifyNumber(
         decimalSeparator = '.',
     } = params;
 
-    const value = clamp(number, min, max).toString().replace('.', decimalSeparator);
+    const value = stringifyNumberWithoutExp(clamp(number, min, max)).replace(
+        '.',
+        decimalSeparator,
+    );
 
     return maskitoTransform(value, maskitoNumberOptionsGenerator(params));
 }

--- a/projects/kit/src/lib/masks/number/utils/tests/stringify-number.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/stringify-number.spec.ts
@@ -68,6 +68,15 @@ describe('maskitoStringifyNumber', () => {
                 }),
             ).toBe('0.00');
         });
+
+        it('number with exponential notation', () => {
+            expect(maskitoStringifyNumber(0.000000012, {maximumFractionDigits: 10})).toBe(
+                '0.000000012',
+            );
+            expect(
+                maskitoStringifyNumber(1.2e-8, {maximumFractionDigits: 10, prefix: '$'}),
+            ).toBe('$0.000000012');
+        });
     });
 
     describe('decimal separator is comma', () => {


### PR DESCRIPTION
Fixes #2223
