### PR TITLE
fix(kit): `PostfixPostprocessor` duplicates postfix on paste of value with incompleted postfix

### DIFF
--- a/projects/demo-integrations/src/tests/component-testing/number/postfix-multi-character.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/number/postfix-multi-character.cy.ts
@@ -1,0 +1,44 @@
+import {maskitoNumberOptionsGenerator} from '@maskito/kit';
+
+import {TestInput} from '../utils';
+
+describe('Number | postfix consists of many characters', () => {
+    describe('postfix = ` lbs. per day`', () => {
+        const maskitoOptions = maskitoNumberOptionsGenerator({
+            postfix: ' lbs. per day',
+            thousandSeparator: ' ',
+            decimalSeparator: '.',
+            maximumFractionDigits: 2,
+        });
+
+        it('Paste 100<space>', () => {
+            cy.mount(TestInput, {componentProperties: {maskitoOptions}});
+            cy.get('input').paste('100 ').should('have.value', '100 lbs. per day');
+        });
+
+        it('Paste 100.<space>', () => {
+            cy.mount(TestInput, {componentProperties: {maskitoOptions}});
+            cy.get('input').paste('100.').should('have.value', '100. lbs. per day');
+        });
+
+        it('Paste 100.42<space>', () => {
+            cy.mount(TestInput, {componentProperties: {maskitoOptions}});
+            cy.get('input').paste('100.42').should('have.value', '100.42 lbs. per day');
+        });
+
+        it('Paste 100 lbs', () => {
+            cy.mount(TestInput, {componentProperties: {maskitoOptions}});
+            cy.get('input').paste('100 lbs').should('have.value', '100 lbs. per day');
+        });
+
+        it('Paste 100 lbs.', () => {
+            cy.mount(TestInput, {componentProperties: {maskitoOptions}});
+            cy.get('input').paste('100 lbs.').should('have.value', '100 lbs. per day');
+        });
+
+        it('Paste 100. lbs.', () => {
+            cy.mount(TestInput, {componentProperties: {maskitoOptions}});
+            cy.get('input').paste('100. lbs.').should('have.value', '100. lbs. per day');
+        });
+    });
+});

--- a/projects/demo-integrations/src/tests/component-testing/number/runtime-postfix-changes/runtime-postfix-changes.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/number/runtime-postfix-changes/runtime-postfix-changes.cy.ts
@@ -1,8 +1,8 @@
-import {MultiTestComponent} from './multi-test.component';
+import {Sandbox} from './sandbox.component';
 
 describe('Number | runtime changes of postfix', () => {
     beforeEach(() => {
-        cy.mount(MultiTestComponent);
+        cy.mount(Sandbox);
         cy.get('input').focus().should('have.value', '1 year').as('input');
     });
 
@@ -13,6 +13,15 @@ describe('Number | runtime changes of postfix', () => {
             .should('have.value', '10 years')
             .should('have.prop', 'selectionStart', '10'.length)
             .should('have.prop', 'selectionEnd', '10'.length);
+    });
+
+    it('1| year => Backspace => Empty', () => {
+        cy.get('@input')
+            .type('{moveToStart}{rightArrow}')
+            .type('{backspace}')
+            .should('have.value', '')
+            .should('have.prop', 'selectionStart', 0)
+            .should('have.prop', 'selectionEnd', 0);
     });
 
     it('10| years => Backspace => 1| year', () => {

--- a/projects/demo-integrations/src/tests/component-testing/number/runtime-postfix-changes/sandbox.component.ts
+++ b/projects/demo-integrations/src/tests/component-testing/number/runtime-postfix-changes/sandbox.component.ts
@@ -39,10 +39,11 @@ export class TestPipe4 implements PipeTransform {
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MultiTestComponent {
+export class Sandbox {
     protected value = '1 year';
 
     protected readonly pluralize = {
+        '=NaN': '',
         one: ' year',
         few: ' years',
         many: ' years',

--- a/projects/demo-integrations/src/tests/kit/number/number-prefix-postfix.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/number/number-prefix-postfix.cy.ts
@@ -358,4 +358,18 @@ describe('Number | Prefix & Postfix', () => {
                 .should('have.prop', 'selectionEnd', 1);
         });
     });
+
+    describe('postfix consists of many characters `lbs_per_day`', () => {
+        it('Paste 100 + incompleted postfix', () => {
+            openNumberPage('postfix=lbs_per_day');
+
+            cy.get('@input')
+                .focus()
+                .should('have.value', 'lbs_per_day')
+                .paste('100lbs')
+                .should('have.value', '100lbs_per_day')
+                .should('have.prop', 'selectionStart', '100'.length)
+                .should('have.prop', 'selectionEnd', '100'.length);
+        });
+    });
 });

--- a/projects/kit/src/lib/processors/postfix-postprocessor.ts
+++ b/projects/kit/src/lib/processors/postfix-postprocessor.ts
@@ -5,7 +5,15 @@ import {escapeRegExp, findCommonBeginningSubstr, identity} from '../utils';
 export function maskitoPostfixPostprocessorGenerator(
     postfix: string,
 ): MaskitoPostprocessor {
-    const postfixRE = new RegExp(`${escapeRegExp(postfix)}$`);
+    const completedPostfixRE = new RegExp(`${escapeRegExp(postfix)}$`);
+    const incompletePostfixRE = new RegExp(
+        postfix &&
+            `(${postfix
+                .split('')
+                .map(escapeRegExp)
+                // eslint-disable-next-line
+                .reduce((acc, _, i, arr) => `${acc}|${arr.slice(0, i + 1).join('')}`)})$`,
+    );
 
     return postfix
         ? ({value, selection}, initialElementState) => {
@@ -15,14 +23,14 @@ export function maskitoPostfixPostprocessorGenerator(
               }
 
               if (
-                  !value.endsWith(postfix) &&
+                  !value.match(incompletePostfixRE) &&
                   !initialElementState.value.endsWith(postfix)
               ) {
                   return {selection, value: value + postfix};
               }
 
               const initialValueBeforePostfix = initialElementState.value.replace(
-                  postfixRE,
+                  completedPostfixRE,
                   '',
               );
               const postfixWasModified =

--- a/projects/kit/src/lib/processors/tests/postfix-postprocessor.spec.ts
+++ b/projects/kit/src/lib/processors/tests/postfix-postprocessor.spec.ts
@@ -34,39 +34,60 @@ describe('maskitoPostfixPostprocessorGenerator', () => {
     });
 
     describe('postfix consists of many characters', () => {
-        const postprocessor = maskitoPostfixPostprocessorGenerator('.00');
+        describe('postfix=.00', () => {
+            const postprocessor = maskitoPostfixPostprocessorGenerator('.00');
 
-        it('does not add postfix if input was initially empty', () => {
-            expect(postprocessor(EMPTY_INPUT, EMPTY_INPUT)).toEqual(EMPTY_INPUT);
+            it('does not add postfix if input was initially empty', () => {
+                expect(postprocessor(EMPTY_INPUT, EMPTY_INPUT)).toEqual(EMPTY_INPUT);
+            });
+
+            it('type 100 => 100.00', () => {
+                expect(
+                    postprocessor(
+                        {value: '100', selection: [3, 3]}, // after
+                        EMPTY_INPUT, // before
+                    ),
+                ).toEqual({value: '100.00', selection: [3, 3]});
+            });
+
+            it('100.0 => 100.00', () => {
+                expect(
+                    postprocessor(
+                        {value: '100.0', selection: [5, 5]}, // after
+                        // attempt to delete character from postfix
+                        {value: '100.00', selection: [6, 6]}, // before
+                    ),
+                ).toEqual({value: '100.00', selection: [5, 5]});
+            });
+
+            it('100. => 100.00', () => {
+                expect(
+                    postprocessor(
+                        {value: '100.', selection: [4, 4]}, // after
+                        // attempt to delete many characters from postfix
+                        {value: '100.00', selection: [6, 6]}, // before
+                    ),
+                ).toEqual({value: '100.00', selection: [4, 4]});
+            });
         });
 
-        it('type 100 => 100.00', () => {
-            expect(
-                postprocessor(
-                    {value: '100', selection: [3, 3]}, // after
-                    EMPTY_INPUT, // before
-                ),
-            ).toEqual({value: '100.00', selection: [3, 3]});
-        });
+        describe('postfix=_lbs_per_day', () => {
+            const postprocessor = maskitoPostfixPostprocessorGenerator('_lbs_per_day');
 
-        it('100.0 => 100.00', () => {
-            expect(
-                postprocessor(
-                    {value: '100.0', selection: [5, 5]}, // after
-                    // attempt to delete character from postfix
-                    {value: '100.00', selection: [6, 6]}, // before
-                ),
-            ).toEqual({value: '100.00', selection: [5, 5]});
-        });
-
-        it('100. => 100.00', () => {
-            expect(
-                postprocessor(
-                    {value: '100.', selection: [4, 4]}, // after
-                    // attempt to delete many characters from postfix
-                    {value: '100.00', selection: [6, 6]}, // before
-                ),
-            ).toEqual({value: '100.00', selection: [4, 4]});
+            it('paste 100 + partially filled postfix => 100_lbs_per_day', () => {
+                expect(
+                    postprocessor(
+                        {
+                            value: '100_lbs',
+                            selection: ['100_lbs'.length, '100_lbs'.length],
+                        },
+                        EMPTY_INPUT,
+                    ),
+                ).toEqual({
+                    value: '100_lbs_per_day',
+                    selection: ['100_lbs'.length, '100_lbs'.length],
+                });
+            });
         });
     });
 


### PR DESCRIPTION
### Reproduction

```ts
const postprocessor = maskitoPostfixPostprocessorGenerator('_lbs_per_day');

it('paste 100 + partially filled postfix => 100_lbs_per_day', () => {
    expect(
        postprocessor(
            {
                value: '100_lbs',
                selection: ['100_lbs'.length, '100_lbs'.length],
            },
            EMPTY_INPUT,
        ),
    ).toEqual({
        value: '100_lbs_per_day',
        selection: ['100_lbs'.length, '100_lbs'.length],
    });
});
```

### Previous behavior
```
- Expected  - 1
+ Received  + 1

  Object {
    "selection": Array [
      7,
      7,
    ],
-   "value": "100_lbs_per_day",
+   "value": "100_lbs_lbs_per_day",
  }

```

### New behavior
Test passes ✅ 