### PR TITLE
fix(kit): resolve circular dependencies inside `Number` mask

### DIFF
--- a/projects/kit/src/lib/constants/default-pseudo-minuses.ts
+++ b/projects/kit/src/lib/constants/default-pseudo-minuses.ts
@@ -1,0 +1,15 @@
+import {
+    CHAR_EM_DASH,
+    CHAR_EN_DASH,
+    CHAR_HYPHEN,
+    CHAR_JP_HYPHEN,
+    CHAR_MINUS,
+} from './unicode-characters';
+
+export const DEFAULT_PSEUDO_MINUSES = [
+    CHAR_HYPHEN,
+    CHAR_EN_DASH,
+    CHAR_EM_DASH,
+    CHAR_JP_HYPHEN,
+    CHAR_MINUS,
+];

--- a/projects/kit/src/lib/constants/index.ts
+++ b/projects/kit/src/lib/constants/index.ts
@@ -1,6 +1,7 @@
 export * from './date-segment-max-values';
 export * from './default-decimal-pseudo-separators';
 export * from './default-min-max-dates';
+export * from './default-pseudo-minuses';
 export * from './default-time-segment-bounds';
 export * from './meridiem';
 export * from './time-fixed-characters';

--- a/projects/kit/src/lib/masks/number/index.ts
+++ b/projects/kit/src/lib/masks/number/index.ts
@@ -3,3 +3,9 @@ export * from './number-params';
 export * from './plugins';
 export * from './processors';
 export * from './utils';
+/*
+Don't put it inside `./utils` entrypoint to avoid circular dependency
+- `stringify-number.ts` uses `maskitoNumberOptionsGenerator`
+- almost all processors and plugins (which are part of `maskitoNumberOptionsGenerator`) uses `./utils`
+ */
+export * from './utils/stringify-number';

--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -2,13 +2,10 @@ import type {MaskitoOptions} from '@maskito/core';
 import {MASKITO_DEFAULT_OPTIONS} from '@maskito/core';
 
 import {
-    CHAR_EM_DASH,
-    CHAR_EN_DASH,
-    CHAR_HYPHEN,
-    CHAR_JP_HYPHEN,
     CHAR_MINUS,
     CHAR_NO_BREAK_SPACE,
     CHAR_ZERO_WIDTH_SPACE,
+    DEFAULT_PSEUDO_MINUSES,
 } from '../../constants';
 import {
     createFullWidthToHalfWidthPreprocessor,
@@ -36,14 +33,6 @@ import {
     emptyPostprocessor,
 } from './processors';
 import {generateMaskExpression, validateDecimalPseudoSeparators} from './utils';
-
-export const DEFAULT_PSEUDO_MINUSES = [
-    CHAR_HYPHEN,
-    CHAR_EN_DASH,
-    CHAR_EM_DASH,
-    CHAR_JP_HYPHEN,
-    CHAR_MINUS,
-];
 
 export function maskitoNumberOptionsGenerator({
     max = Number.MAX_SAFE_INTEGER,

--- a/projects/kit/src/lib/masks/number/utils/index.ts
+++ b/projects/kit/src/lib/masks/number/utils/index.ts
@@ -2,6 +2,5 @@ export * from './extract-affixes';
 export * from './generate-mask-expression';
 export * from './number-parts';
 export * from './parse-number';
-export * from './stringify-number';
 export * from './stringify-number-without-exp';
 export * from './validate-decimal-pseudo-separators';

--- a/projects/kit/src/lib/masks/number/utils/parse-number.ts
+++ b/projects/kit/src/lib/masks/number/utils/parse-number.ts
@@ -1,6 +1,5 @@
-import {CHAR_HYPHEN} from '../../../constants';
+import {CHAR_HYPHEN, DEFAULT_PSEUDO_MINUSES} from '../../../constants';
 import {escapeRegExp} from '../../../utils';
-import {DEFAULT_PSEUDO_MINUSES} from '../number-mask';
 import type {MaskitoNumberParams} from '../number-params';
 
 export function maskitoParseNumber(

--- a/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
@@ -7,8 +7,8 @@ import {
     CHAR_HYPHEN,
     CHAR_JP_HYPHEN,
     CHAR_MINUS,
+    DEFAULT_PSEUDO_MINUSES,
 } from '../../../../constants';
-import {DEFAULT_PSEUDO_MINUSES} from '../../number-mask';
 import {toNumberParts} from '../number-parts';
 
 const DEFAULT_PARAMS = {


### PR DESCRIPTION
Run `nx build kit`

```
> nx run kit:build

Bundling kit...
Circular dependency: 
    projects/kit/src/lib/masks/number/number-mask.ts -> 
    projects/kit/src/lib/masks/number/plugins/index.ts -> 
    projects/kit/src/lib/masks/number/plugins/leading-zeroes-validation.plugin.ts -> 
    projects/kit/src/lib/masks/number/processors/index.ts -> 
    projects/kit/src/lib/masks/number/processors/affixes-filter-preprocessor.ts -> 
    projects/kit/src/lib/masks/number/utils/index.ts -> 
    projects/kit/src/lib/masks/number/utils/parse-number.ts -> 
    projects/kit/src/lib/masks/number/number-mask.ts
Circular dependency: 
    projects/kit/src/lib/masks/number/number-mask.ts ->
    projects/kit/src/lib/masks/number/plugins/index.ts ->
    projects/kit/src/lib/masks/number/plugins/leading-zeroes-validation.plugin.ts ->
    projects/kit/src/lib/masks/number/processors/index.ts -> 
    projects/kit/src/lib/masks/number/processors/affixes-filter-preprocessor.ts ->
    projects/kit/src/lib/masks/number/utils/index.ts ->
    projects/kit/src/lib/masks/number/utils/stringify-number.ts ->
    projects/kit/src/lib/masks/number/number-mask.ts
  index.esm.js 102.885 KB
  index.cjs.js 103.677 KB
⚡ Done in 1.16s

```