### PR TITLE
docs: add anchor links to React docs sections

### DIFF
--- a/projects/demo/src/pages/frameworks/react/react-doc.component.ts
+++ b/projects/demo/src/pages/frameworks/react/react-doc.component.ts
@@ -1,9 +1,11 @@
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {Clipboard} from '@angular/cdk/clipboard';
+import {DOCUMENT} from '@angular/common';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {DemoPath} from '@demo/constants';
 import type {TuiRawLoaderContent} from '@taiga-ui/addon-doc';
-import {TuiAddonDoc} from '@taiga-ui/addon-doc';
-import {TuiLink, TuiNotification} from '@taiga-ui/core';
+import {TUI_DOC_EXAMPLE_TEXTS, TuiAddonDoc} from '@taiga-ui/addon-doc';
+import {TuiAlertService, TuiLink, TuiNotification} from '@taiga-ui/core';
 import {TuiTabs} from '@taiga-ui/kit';
 
 import {ReactExample1} from './examples/1-use-maskito-basic-usage/example.component';
@@ -25,6 +27,14 @@ import {ReactExample2} from './examples/2-element-predicate/example.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class ReactDocPageComponent {
+    private readonly documentRef = inject(DOCUMENT);
+    private readonly clipboard = inject(Clipboard);
+    private readonly alerts = inject(TuiAlertService);
+    private readonly docExampleTexts = inject(TUI_DOC_EXAMPLE_TEXTS);
+    private readonly copyLinkMessage = this.docExampleTexts[1] ?? '';
+    private readonly copyLinkLabel = this.docExampleTexts[2] ?? '';
+    protected readonly copyLinkTooltip = this.docExampleTexts[0] ?? '';
+
     protected readonly coreConceptsOverviewDocPage = `/${DemoPath.CoreConceptsOverview}`;
     protected readonly useMaskitoBasicUsage = import(
         './examples/1-use-maskito-basic-usage/use-maskito-basic-usage.tsx?raw',
@@ -55,4 +65,25 @@ export default class ReactDocPageComponent {
     };
 
     protected readonly bestBadPractice = import('./examples/best-bad-practice.md');
+
+    protected copyAnchorLink(event: MouseEvent): void {
+        const anchor = event.currentTarget as HTMLAnchorElement | null;
+
+        if (!anchor) {
+            return;
+        }
+
+        const href =
+            anchor.href ||
+            `${this.documentRef.location.href.split('#')[0]}${anchor.getAttribute('href') ?? ''}`;
+
+        this.clipboard.copy(href);
+
+        this.alerts
+            .open(this.copyLinkMessage, {
+                label: this.copyLinkLabel,
+                appearance: 'positive',
+            })
+            .subscribe();
+    }
 }

--- a/projects/demo/src/pages/frameworks/react/react-doc.style.less
+++ b/projects/demo/src/pages/frameworks/react/react-doc.style.less
@@ -9,3 +9,29 @@
 section {
     margin-block-start: 3.5rem;
 }
+
+.section-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.section-heading__title {
+    margin: 0;
+}
+
+.section-heading__link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 1.5rem;
+    block-size: 1.5rem;
+    font: inherit;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+
+section:hover .section-heading__link,
+.section-heading__link:focus-visible {
+    opacity: 1;
+}

--- a/projects/demo/src/pages/frameworks/react/react-doc.template.html
+++ b/projects/demo/src/pages/frameworks/react/react-doc.template.html
@@ -29,7 +29,20 @@
     </tui-notification>
 
     <section id="getting-started">
-        <h2>Getting Started</h2>
+        <header class="section-heading">
+            <h2 class="section-heading__title">Getting Started</h2>
+
+            <a
+                aria-label="Copy link to Getting Started"
+                href="#getting-started"
+                tuiLink
+                class="section-heading__link"
+                [attr.title]="copyLinkTooltip"
+                (click)="copyAnchorLink($event)"
+            >
+                #
+            </a>
+        </header>
 
         <p>Install libraries</p>
 
@@ -50,7 +63,20 @@
     </section>
 
     <section id="controlled-input">
-        <h2>Controlled masked input</h2>
+        <header class="section-heading">
+            <h2 class="section-heading__title">Controlled masked input</h2>
+
+            <a
+                aria-label="Copy link to Controlled masked input"
+                href="#controlled-input"
+                tuiLink
+                class="section-heading__link"
+                [attr.title]="copyLinkTooltip"
+                (click)="copyAnchorLink($event)"
+            >
+                #
+            </a>
+        </header>
 
         <p>
             <strong>Maskito</strong>
@@ -89,7 +115,20 @@
     </section>
 
     <section id="merge-refs">
-        <h2>Merge Maskito ref with the third-party ref</h2>
+        <header class="section-heading">
+            <h2 class="section-heading__title">Merge Maskito ref with the third-party ref</h2>
+
+            <a
+                aria-label="Copy link to Merge Maskito ref with the third-party ref"
+                href="#merge-refs"
+                tuiLink
+                class="section-heading__link"
+                [attr.title]="copyLinkTooltip"
+                (click)="copyAnchorLink($event)"
+            >
+                #
+            </a>
+        </header>
 
         <p>Do you need to use multiple hooks that return refs which both should be attached to the masked textfield?</p>
 
@@ -112,7 +151,20 @@
     </section>
 
     <section id="element-predicate">
-        <h2>Query nested input element</h2>
+        <header class="section-heading">
+            <h2 class="section-heading__title">Query nested input element</h2>
+
+            <a
+                aria-label="Copy link to Query nested input element"
+                href="#element-predicate"
+                tuiLink
+                class="section-heading__link"
+                [attr.title]="copyLinkTooltip"
+                (click)="copyAnchorLink($event)"
+            >
+                #
+            </a>
+        </header>
 
         <p>
             Pass a predicate to
@@ -140,7 +192,20 @@
     </section>
 
     <section id="form-library-integration">
-        <h2>Integration with third-party library for forms</h2>
+        <header class="section-heading">
+            <h2 class="section-heading__title">Integration with third-party library for forms</h2>
+
+            <a
+                aria-label="Copy link to Integration with third-party library for forms"
+                href="#form-library-integration"
+                tuiLink
+                class="section-heading__link"
+                [attr.title]="copyLinkTooltip"
+                (click)="copyAnchorLink($event)"
+            >
+                #
+            </a>
+        </header>
 
         <p>
             There is not silver bullet how to integrate
@@ -197,8 +262,21 @@
         }
     </section>
 
-    <section>
-        <h2>Best practices & Anti-Patterns</h2>
+    <section id="best-practices">
+        <header class="section-heading">
+            <h2 class="section-heading__title">Best practices &amp; Anti-Patterns</h2>
+
+            <a
+                aria-label="Copy link to Best practices and Anti-Patterns"
+                href="#best-practices"
+                tuiLink
+                class="section-heading__link"
+                [attr.title]="copyLinkTooltip"
+                (click)="copyAnchorLink($event)"
+            >
+                #
+            </a>
+        </header>
 
         <p>
             Pass named variables to avoid unnecessary hook runs with


### PR DESCRIPTION
## Summary
- add anchor links to each section of the React documentation page
- copy the section URL to the clipboard and reuse existing doc texts for messaging
- keep the link indicator hidden until hover/focus to avoid visual noise

Closes #1757.

## Testing
- `npx eslint projects/demo/src/pages/frameworks/react/react-doc.component.ts`
- `npx stylelint projects/demo/src/pages/frameworks/react/react-doc.style.less`
- `npx nx test demo --configuration=production`