### PR TITLE
feat(kit)!: delete deprecated `precision` & `decimalZeroPadding` parameters from `Number` mask

### DIFF
--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -37,11 +37,9 @@ import {generateMaskExpression, validateDecimalPseudoSeparators} from './utils';
 export function maskitoNumberOptionsGenerator({
     max = Number.MAX_SAFE_INTEGER,
     min = Number.MIN_SAFE_INTEGER,
-    precision = 0,
     thousandSeparator = CHAR_NO_BREAK_SPACE,
     decimalSeparator = '.',
     decimalPseudoSeparators: unsafeDecimalPseudoSeparators,
-    decimalZeroPadding = false,
     prefix = '',
     postfix = '',
     minusSign = CHAR_MINUS,
@@ -49,8 +47,8 @@ export function maskitoNumberOptionsGenerator({
         (char) =>
             char !== thousandSeparator && char !== decimalSeparator && char !== minusSign,
     ),
-    maximumFractionDigits = precision,
-    minimumFractionDigits = decimalZeroPadding ? maximumFractionDigits : 0,
+    maximumFractionDigits = 0,
+    minimumFractionDigits = 0,
     negativePattern = 'prefixFirst',
 }: MaskitoNumberParams = {}): Required<MaskitoOptions> {
     const decimalPseudoSeparators = validateDecimalPseudoSeparators({
@@ -62,7 +60,6 @@ export function maskitoNumberOptionsGenerator({
     const params: Required<MaskitoNumberParams> = {
         max,
         min,
-        precision,
         thousandSeparator,
         postfix,
         minusSign,
@@ -70,7 +67,6 @@ export function maskitoNumberOptionsGenerator({
         maximumFractionDigits,
         decimalPseudoSeparators,
         negativePattern,
-        decimalZeroPadding,
         decimalSeparator:
             maximumFractionDigits <= 0 && decimalSeparator === thousandSeparator
                 ? ''

--- a/projects/kit/src/lib/masks/number/number-params.ts
+++ b/projects/kit/src/lib/masks/number/number-params.ts
@@ -5,18 +5,8 @@ export interface MaskitoNumberParams
     > {
     min?: number;
     max?: number;
-    /**
-     * TODO(v4): delete
-     * @deprecated use `maximumFractionDigits` instead
-     */
-    precision?: number;
     decimalSeparator?: string;
-    decimalPseudoSeparators?: string[]; // TODO(v4): => readonly string[]
-    /**
-     * TODO(v4): delete
-     * @deprecated use `minimumFractionDigits` instead
-     */
-    decimalZeroPadding?: boolean;
+    decimalPseudoSeparators?: readonly string[];
     thousandSeparator?: string;
     prefix?: string;
     postfix?: string;

--- a/projects/kit/src/lib/masks/number/processors/tests/leading-zeroes-validation-postprocessor.spec.ts
+++ b/projects/kit/src/lib/masks/number/processors/tests/leading-zeroes-validation-postprocessor.spec.ts
@@ -8,7 +8,7 @@ const DEFAULT_PARAMS = {
     prefix: '',
     postfix: '',
     minusPseudoSigns: [],
-    decimalPseudoSeparators: [','] as string[], // TODO(v4): remove `as string[]`
+    decimalPseudoSeparators: [','],
     negativePattern: 'prefixFirst',
 } as const satisfies MaskitoNumberParams;
 

--- a/projects/kit/src/lib/masks/number/processors/tests/not-empty-integer-part-preprocessor.spec.ts
+++ b/projects/kit/src/lib/masks/number/processors/tests/not-empty-integer-part-preprocessor.spec.ts
@@ -12,7 +12,7 @@ const DEFAULT_PARAMS = {
     prefix: '',
     postfix: '',
     minusPseudoSigns: [],
-    decimalPseudoSeparators: [','] as string[], // TODO(v4): remove `as string[]`
+    decimalPseudoSeparators: [','],
     negativePattern: 'prefixFirst',
 } as const satisfies MaskitoNumberParams;
 

--- a/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/to-number-parts.spec.ts
@@ -18,7 +18,7 @@ const DEFAULT_PARAMS = {
     decimalSeparator: '.',
     minusSign: '-',
     maximumFractionDigits: 0,
-    decimalPseudoSeparators: [','] as string[], // TODO(v4): remove `as string[]`
+    decimalPseudoSeparators: [','],
 } as const satisfies MaskitoNumberParams;
 
 describe('toNumberParts', () => {
@@ -129,7 +129,7 @@ describe('toNumberParts', () => {
                     minusSign: minus,
                     maximumFractionDigits: 2,
                     decimalSeparator: '.',
-                    decimalPseudoSeparators: ['б'] as string[], // TODO(v4): delete `as string[]`
+                    decimalPseudoSeparators: ['б'],
                     thousandSeparator: ',',
                 } as const satisfies MaskitoNumberParams;
 

--- a/projects/kit/src/lib/masks/number/utils/validate-decimal-pseudo-separators.ts
+++ b/projects/kit/src/lib/masks/number/utils/validate-decimal-pseudo-separators.ts
@@ -7,7 +7,7 @@ export function validateDecimalPseudoSeparators({
 }: {
     decimalSeparator: string;
     thousandSeparator: string;
-    decimalPseudoSeparators?: string[];
+    decimalPseudoSeparators?: readonly string[];
 }): string[] {
     return decimalPseudoSeparators.filter(
         (char) => char !== thousandSeparator && char !== decimalSeparator,


### PR DESCRIPTION
## Legacy API
```ts
import {maskitoNumberOptionsGenerator} from '@maskito/kit';
 
const options = maskitoNumberOptionsGenerator({
    precision: 2, // ---> Use `maximumFractionDigits` instead
    decimalZeroPadding: true, // ---> Use `minimumFractionDigits` instead
});
```

## New API
```ts
import {maskitoNumberOptionsGenerator} from '@maskito/kit';
 
const options = maskitoNumberOptionsGenerator({
    maximumFractionDigits: 2,
    minimumFractionDigits: 2,
});
```

## Why?
New naming is inspired by native web terminology – `Intl.NumberFormat`-like API:
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#minimumsignificantdigits
