### PR TITLE
feat(kit)!: `maskitoParseNumber` accepts only `MaskitoNumberParams` as the 2nd argument

### DIFF
--- a/projects/kit/src/lib/masks/number/utils/parse-number.ts
+++ b/projects/kit/src/lib/masks/number/utils/parse-number.ts
@@ -4,16 +4,12 @@ import type {MaskitoNumberParams} from '../number-params';
 
 export function maskitoParseNumber(
     maskedNumber: string,
-    // TODO(v4): decimalSeparatorOrParams: MaskitoNumberParams | string => params: MaskitoNumberParams = {}
-    decimalSeparatorOrParams: MaskitoNumberParams | string = {},
-): number {
-    const {
+    {
         decimalSeparator = '.',
         minusSign = '',
         minusPseudoSigns = DEFAULT_PSEUDO_MINUSES,
-    }: MaskitoNumberParams = typeof decimalSeparatorOrParams === 'string'
-        ? {decimalSeparator: decimalSeparatorOrParams}
-        : decimalSeparatorOrParams;
+    }: MaskitoNumberParams = {},
+): number {
     const hasNegativeSign = !!new RegExp(
         `^\\D*[${escapeRegExp(minusSign)}\\${minusPseudoSigns.join('\\')}]`,
     ).exec(maskedNumber);

--- a/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
@@ -213,7 +213,7 @@ describe('maskitoParseNumber', () => {
 
         it('decimal separator only => NaN', () => {
             expect(maskitoParseNumber('.')).toBeNaN();
-            expect(maskitoParseNumber(',', ',')).toBeNaN();
+            expect(maskitoParseNumber(',', {decimalSeparator: ','})).toBeNaN();
         });
 
         it('negative sign only => NaN', () => {


### PR DESCRIPTION
## Legacy API
```ts
import {maskitoParseNumber} from '@maskito/kit';
 
maskitoParseNumber(
    '0,42',
    ',' // decimalSeparator
)
```

## New API
```ts
import {maskitoParseNumber} from '@maskito/kit';
 
maskitoParseNumber(
    '0,42',
    { decimalSeparator: ',' } // MaskitoNumberParams
)
```

## Why?
API is changed due to uniformity with other similar maskito helpers:
```ts
maskitoParseDate(
    '01.01.2000',
    { mode: 'dd/mm/yyyy' } // MaskitoDateParams
);
// + maskitoStringifyDate(..., params)

maskitoParseTime(
    '12:34',
    { mode: 'HH:MM' } // MaskitoTimeParams
);
// + maskitoStringifyTime(..., params)

maskitoParseDateTime(
    '01.01.2000, 12:34',
    { dateMode: 'dd/mm/yyyy' } // MaskitoDateTimeParams
);
// + maskitoStringifyDateTime(..., params)
```