### PR TITLE
refactor(demo): use `styleUrl` instead of `styleUrls` for components with single stylesheet

### DIFF
--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -13,7 +13,7 @@ import {debounceTime, map, startWith} from 'rxjs';
     selector: 'app',
     imports: [RouterLink, TuiDocMain, TuiLink],
     templateUrl: './app.component.html',
-    styleUrls: ['./app.style.less'],
+    styleUrl: './app.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
         ResizeObserverService,

--- a/projects/demo/src/app/modules/logo/logo.component.ts
+++ b/projects/demo/src/app/modules/logo/logo.component.ts
@@ -7,7 +7,7 @@ import {PolymorpheusComponent} from '@taiga-ui/polymorpheus';
     selector: 'logo',
     imports: [RouterLink, TuiLink],
     templateUrl: './logo.template.html',
-    styleUrls: ['./logo.style.less'],
+    styleUrl: './logo.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LogoComponent {}

--- a/projects/demo/src/pages/documentation/core-concepts-overview/core-concepts-overview.component.ts
+++ b/projects/demo/src/pages/documentation/core-concepts-overview/core-concepts-overview.component.ts
@@ -21,7 +21,7 @@ import {TuiCardLarge, TuiHeader} from '@taiga-ui/layout';
         TuiTooltip,
     ],
     templateUrl: './core-concepts-overview.template.html',
-    styleUrls: ['./core-concepts-overview.styles.less'],
+    styleUrl: './core-concepts-overview.styles.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class CoreConceptsOverviewDocPageComponent {

--- a/projects/demo/src/pages/documentation/plugins/plugins.component.ts
+++ b/projects/demo/src/pages/documentation/plugins/plugins.component.ts
@@ -33,7 +33,7 @@ import documentationMask from './examples/pads-zero-plugin';
         TuiTitle,
     ],
     templateUrl: './plugins.template.html',
-    styleUrls: ['./plugins.style.less'],
+    styleUrl: './plugins.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class PluginsDocPageComponent {

--- a/projects/demo/src/pages/documentation/real-world-form/index.ts
+++ b/projects/demo/src/pages/documentation/real-world-form/index.ts
@@ -39,7 +39,7 @@ const ONLY_LATIN_LETTERS_RE = /^[a-z]+$/i;
         TuiTextfieldControllerModule,
     ],
     templateUrl: './index.html',
-    styleUrls: ['./index.less'],
+    styleUrl: './index.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class RealWorldForm {

--- a/projects/demo/src/pages/documentation/what-is-maskito/what-is-maskito.component.ts
+++ b/projects/demo/src/pages/documentation/what-is-maskito/what-is-maskito.component.ts
@@ -19,7 +19,7 @@ import {TuiCardLarge, TuiHeader} from '@taiga-ui/layout';
         TuiTitle,
     ],
     templateUrl: './what-is-maskito.template.html',
-    styleUrls: ['./what-is-maskito.style.less'],
+    styleUrl: './what-is-maskito.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class WhatIsMaskitoDocPageComponent {

--- a/projects/demo/src/pages/frameworks/react/react-doc.component.ts
+++ b/projects/demo/src/pages/frameworks/react/react-doc.component.ts
@@ -21,7 +21,7 @@ import {ReactExample2} from './examples/2-element-predicate/example.component';
         TuiTabs,
     ],
     templateUrl: './react-doc.template.html',
-    styleUrls: ['./react-doc.style.less'],
+    styleUrl: './react-doc.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class ReactDocPageComponent {

--- a/projects/demo/src/pages/kit/date/date-mask-doc.component.ts
+++ b/projects/demo/src/pages/kit/date/date-mask-doc.component.ts
@@ -27,7 +27,7 @@ import {DateMaskDocExample2} from './examples/2-min-max/component';
         TuiTextfieldControllerModule,
     ],
     templateUrl: './date-mask-doc.template.html',
-    styleUrls: ['./date-mask-doc.style.less'],
+    styleUrl: './date-mask-doc.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class DateMaskDocComponent implements Required<MaskitoDateParams> {

--- a/projects/demo/src/pages/kit/plugins/examples/4-reject/component.ts
+++ b/projects/demo/src/pages/kit/plugins/examples/4-reject/component.ts
@@ -24,7 +24,7 @@ import mask from './mask';
             />
         </tui-input>
     `,
-    styleUrls: ['./animation.less'],
+    styleUrl: './animation.less',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/demo/src/pages/kit/time/time-mask-doc.component.ts
+++ b/projects/demo/src/pages/kit/time/time-mask-doc.component.ts
@@ -35,7 +35,7 @@ import {TimeMaskDocExample5} from './examples/5-time-segments-min-max/component'
         TuiTextfieldControllerModule,
     ],
     templateUrl: './time-mask-doc.template.html',
-    styleUrls: ['./time-mask-doc.style.less'],
+    styleUrl: './time-mask-doc.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class TimeMaskDocComponent implements Required<MaskitoTimeParams> {

--- a/projects/demo/src/pages/phone/phone-doc.component.ts
+++ b/projects/demo/src/pages/phone/phone-doc.component.ts
@@ -53,7 +53,7 @@ type MetadataName = keyof typeof metadataSets;
         TuiTextfieldControllerModule,
     ],
     templateUrl: './phone-doc.template.html',
-    styleUrls: ['./phone-doc.style.less'],
+    styleUrl: './phone-doc.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class PhoneDocComponent implements GeneratorOptions {

--- a/projects/demo/src/pages/recipes/card/examples/1-basic/component.ts
+++ b/projects/demo/src/pages/recipes/card/examples/1-basic/component.ts
@@ -10,7 +10,7 @@ import {TuiInputModule} from '@taiga-ui/legacy';
     selector: 'card-doc-example-1',
     imports: [MaskitoDirective, ReactiveFormsModule, TuiGroup, TuiInputModule],
     templateUrl: './template.html',
-    styleUrls: ['./style.less'],
+    styleUrl: './style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CardDocExample1 {

--- a/projects/demo/src/pages/stackblitz/components/stackblitz-edit-button/stackblitz-edit-button.component.ts
+++ b/projects/demo/src/pages/stackblitz/components/stackblitz-edit-button/stackblitz-edit-button.component.ts
@@ -16,7 +16,7 @@ import {TuiButton} from '@taiga-ui/core';
             Edit
         </button>
     `,
-    styleUrls: ['./stackblitz-edit-button.style.less'],
+    styleUrl: './stackblitz-edit-button.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StackblitzEditButtonComponent {}

--- a/projects/demo/src/pages/stackblitz/components/stackblitz-starter/stackblitz-starter.component.ts
+++ b/projects/demo/src/pages/stackblitz/components/stackblitz-starter/stackblitz-starter.component.ts
@@ -17,7 +17,7 @@ import {StackblitzService} from '../../stackblitz.service';
             [overlay]="true"
         ></tui-loader>
     `,
-    styleUrls: ['./stackblitz-starter.style.less'],
+    styleUrl: './stackblitz-starter.style.less',
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [StackblitzService],
 })


### PR DESCRIPTION
Search:
```
styleUrls: \['([^']*)'\]
```

Replace:
```
styleUrl: '$1'
```

https://blog.angular.dev/introducing-angular-v17-4d7033312e4b#de9c