### PR TITLE
chore(demo): remove CommonJs dependencies warnings

### DIFF
--- a/projects/demo/project.json
+++ b/projects/demo/project.json
@@ -38,7 +38,14 @@
                     "entry": "{projectRoot}/src/server.ts"
                 },
                 "outputMode": "server",
-                "allowedCommonJsDependencies": ["react-dom/client"],
+                "allowedCommonJsDependencies": [
+                    "react",
+                    "react-dom/client",
+                    "react/jsx-runtime",
+                    "@vue/compiler-dom",
+                    "@vue/runtime-dom",
+                    "@vue/shared"
+                ],
                 "loader": {
                     ".md": "text",
                     ".html": "text",

--- a/projects/demo/src/pages/phone/phone-doc.component.ts
+++ b/projects/demo/src/pages/phone/phone-doc.component.ts
@@ -14,12 +14,12 @@ import {
     TuiInputModule,
     TuiTextfieldControllerModule,
 } from '@taiga-ui/legacy';
+import type {MetadataJson} from 'libphonenumber-js';
 import type {CountryCode} from 'libphonenumber-js/core';
 import {getCountries, getCountryCallingCode} from 'libphonenumber-js/core';
 import maxMetadata from 'libphonenumber-js/max/metadata';
 import minMetadata from 'libphonenumber-js/min/metadata';
 import mobileMetadata from 'libphonenumber-js/mobile/metadata';
-import type {MetadataJson} from 'libphonenumber-js/types';
 
 import {PhoneMaskDocExample1} from './examples/1-basic/component';
 import {PhoneMaskDocExample2} from './examples/2-validation/component';


### PR DESCRIPTION
## Problem
Run 
```
npm run build
```

It succeeded but its logs contains warnings:
```
▲ [WARNING] Module 'react/jsx-runtime' used by 'projects/demo/src/pages/frameworks/react/examples/1-use-maskito-basic-usage/example.component.tsx' is not ESM

  CommonJS or AMD dependencies can cause optimization bailouts.
  For more information see: https://angular.dev/tools/cli/build#configuring-commonjs-dependencies


▲ [WARNING] Module 'react' used by 'projects/demo/src/pages/frameworks/react/examples/2-element-predicate/awesome-input.tsx' is not ESM

  CommonJS or AMD dependencies can cause optimization bailouts.
  For more information see: https://angular.dev/tools/cli/build#configuring-commonjs-dependencies


▲ [WARNING] Module '@vue/compiler-dom' used by 'node_modules/vue/dist/vue.cjs.prod.js' is not ESM

  CommonJS or AMD dependencies can cause optimization bailouts.
  For more information see: https://angular.dev/tools/cli/build#configuring-commonjs-dependencies


▲ [WARNING] Module '@vue/runtime-dom' used by 'node_modules/vue/dist/vue.cjs.prod.js' is not ESM

  CommonJS or AMD dependencies can cause optimization bailouts.
  For more information see: https://angular.dev/tools/cli/build#configuring-commonjs-dependencies


▲ [WARNING] Module '@vue/shared' used by 'node_modules/vue/dist/vue.cjs.prod.js' is not ESM

  CommonJS or AMD dependencies can cause optimization bailouts.
  For more information see: https://angular.dev/tools/cli/build#configuring-commonjs-dependencies
```


## Why React ?
React still ships only CommonJS package format (both issues are opened from 2017 😄 ):
> Currently we only ship CommonJS versions of all packages. 
> However we might want to ship them as ESM in the future

* https://github.com/facebook/react/issues/11503
* https://github.com/facebook/react/issues/10021

## Why Vue ?
Esbuild (Angular SSR) uses [the following exports](https://github.com/vuejs/core/blob/45547e69b25baa99a0ed52ba5110c5bd8b4a35e4/packages/vue/package.json#L19-L23):

```json
"exports": {
    ".": {
      "import": {
        "types": "./dist/vue.d.mts",
        "node": "./index.mjs",
```

```
import => node => ./index.mjs
```

[index.mjs](https://github.com/vuejs/core/blob/main/packages/vue/index.mjs) contains single line:
```js
export * from './index.js'
```

and [index.js](https://github.com/vuejs/core/blob/main/packages/vue/index.js) contains:
```js
'use strict'

if (process.env.NODE_ENV === 'production') {
  module.exports = require('./dist/vue.cjs.prod.js')
} else {
  module.exports = require('./dist/vue.cjs.js')
}
```

ESM file imports CJS ???
Why ??? 
😢 