### PR TITLE
fix(kit): `maskitoStringifyNumber` supports extremal exponent values

### DIFF
--- a/projects/kit/src/lib/masks/number/utils/stringify-number-without-exp.ts
+++ b/projects/kit/src/lib/masks/number/utils/stringify-number-without-exp.ts
@@ -1,21 +1,69 @@
+import {CHAR_HYPHEN} from '../../../constants';
+import {toNumberParts} from './number-parts';
+
+const LOCALE: Intl.Locale[] = [];
+const DEFAULT = {
+    minusSign: CHAR_HYPHEN,
+    minusPseudoSigns: [],
+    prefix: '',
+    postfix: '',
+    decimalSeparator: '.',
+    decimalPseudoSeparators: [],
+    maximumFractionDigits: Infinity,
+};
+
 /**
- * Convert number to string with replacing exponent part on decimals
+ * Converts a number to a decimal string without using exponential notation.
  *
- * @param value the number
- * @return string representation of a number
+ * - Numbers without exponent are returned as-is.
+ * - Numbers with a positive exponent (`e+N`) are expanded using locale formatting.
+ * - Numbers with a negative exponent (`e-N`) are expanded manually to avoid
+ *   precision limits of `Number#toFixed` and locale rounding.
+ *
+ * The sign of the number and the sign of the exponent are handled independently.
+ * This guarantees correct formatting for cases like `-1.23e-8`.
+ *
+ * @param value Number or bigint to convert.
+ * @returns Full decimal string representation without exponent notation.
+ *
+ * @example
+ * stringifyNumberWithoutExp(1e25)
+ * // "10000000000000000000000000"
+ *
+ * @example
+ * stringifyNumberWithoutExp(1.23e-8)
+ * // "0.0000000123"
+ *
+ * @example
+ * stringifyNumberWithoutExp(-1.23e-8)
+ * // "-0.0000000123"
  */
 export function stringifyNumberWithoutExp(value: bigint | number): string {
     const valueAsString = String(value);
-    const [numberPart = '', expPart] = valueAsString.split('e-');
+    const [numberPart = '', exponent] = valueAsString.split('e');
 
-    let valueWithoutExp = valueAsString;
-
-    if (expPart && typeof value === 'number') {
-        const [, fractionalPart] = numberPart.split('.');
-        const decimalDigits = Number(expPart) + (fractionalPart?.length ?? 0);
-
-        valueWithoutExp = value.toFixed(decimalDigits);
+    if (!exponent) {
+        return valueAsString;
     }
 
-    return valueWithoutExp;
+    if (!exponent.startsWith(CHAR_HYPHEN)) {
+        return value.toLocaleString(LOCALE, {useGrouping: false});
+    }
+
+    const {minus, integerPart, decimalPart} = toNumberParts(numberPart, DEFAULT);
+    const digits = integerPart + decimalPart;
+    const shift = Math.abs(Number(exponent));
+    const totalZeros = shift - integerPart.length;
+
+    let result: string;
+
+    if (totalZeros >= 0) {
+        result = `0.${'0'.repeat(totalZeros)}${digits}`;
+    } else {
+        const index = integerPart.length - shift;
+
+        result = `${digits.slice(0, index)}.${digits.slice(index)}`;
+    }
+
+    return minus + result;
 }

--- a/projects/kit/src/lib/masks/number/utils/tests/stringify-number-without-exp.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/stringify-number-without-exp.spec.ts
@@ -38,4 +38,44 @@ describe('number converting to string without exponent', () => {
     it('fractional value with exponent and precision equals 4', () => {
         expect(stringifyNumberWithoutExp(2.23e-2)).toBe('0.0223');
     });
+
+    it('very small exponent that exceeds toFixed limit must expand manually', () => {
+        expect(stringifyNumberWithoutExp(102.282e-112)).toBe(
+            '0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000102282',
+        );
+    });
+
+    it('positive exponent should use full wide expansion', () => {
+        expect(stringifyNumberWithoutExp(1e25)).toBe('10000000000000000000000000');
+    });
+
+    it('zero', () => {
+        expect(stringifyNumberWithoutExp(0)).toBe('0');
+    });
+
+    it('negative zero formatted correctly', () => {
+        expect(stringifyNumberWithoutExp(-0)).toBe('0');
+    });
+
+    it('bigint basic', () => {
+        expect(stringifyNumberWithoutExp(123n)).toBe('123');
+    });
+
+    it('negative bigint', () => {
+        expect(stringifyNumberWithoutExp(-999999999999999999999n)).toBe(
+            '-999999999999999999999',
+        );
+    });
+
+    it('large negative exponent simple case', () => {
+        expect(stringifyNumberWithoutExp(5e-5)).toBe('0.00005');
+    });
+
+    it('decimal with many zeros inside exponent', () => {
+        expect(stringifyNumberWithoutExp(9.001e-4)).toBe('0.0009001');
+    });
+
+    it('positive exponent with fractional part', () => {
+        expect(stringifyNumberWithoutExp(3.14e5)).toBe('314000');
+    });
 });

--- a/projects/kit/src/lib/masks/number/utils/tests/stringify-number.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/stringify-number.spec.ts
@@ -77,6 +77,12 @@ describe('maskitoStringifyNumber', () => {
             expect(
                 maskitoStringifyNumber(1.2e-8, {maximumFractionDigits: 10, prefix: '$'}),
             ).toBe('$0.000000012');
+
+            expect(
+                maskitoStringifyNumber(2e24, {
+                    thousandSeparator: '_',
+                }),
+            ).toBe('2_000_000_000_000_000_000_000_000');
         });
     });
 


### PR DESCRIPTION
Fixes #2462
