### PR TITLE
chore: fix WebStorm runner for Jest tests

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -9,7 +9,7 @@ module.exports = {
             {
                 diagnostics: true,
                 stringifyContentPathRegex: String.raw`\.html$`,
-                tsconfig: resolve(process.cwd(), 'tsconfig.spec.json'),
+                tsconfig: resolve(__dirname, 'tsconfig.spec.json'),
             },
         ],
     },


### PR DESCRIPTION
Revert a line from these changes:
* https://github.com/taiga-family/maskito/pull/2475/changes#diff-4a3dfd1441f8f6e290336bb5ca65bd4e7f3f53b9583de0f5845449170b214d58L8-R12

Try to run any Jest test using WebStorm.
For example, `projects/kit/src/lib/masks/number/tests/number-mask.spec.ts`
<img height="250" alt="webstorm-run-jest" src="https://github.com/user-attachments/assets/ecd2a877-d12b-403b-9868-a80b49d6b162" />

It will fail with error
<img height="300" alt="error" src="https://github.com/user-attachments/assets/0f5170d3-0647-49e7-81b7-9f44e9cd2044" />