### PR TITLE
fix(react): `useMaskito` should destroy Maskito instance if element is detached from the DOM

### DIFF
--- a/projects/react/src/lib/useMaskito.ts
+++ b/projects/react/src/lib/useMaskito.ts
@@ -70,6 +70,10 @@ export const useMaskito = ({
         } else {
             setElement(elementOrPromise);
         }
+
+        return () => {
+            setElement(null);
+        };
     }, [hostElement, elementPredicate, latestPredicateRef, options, latestOptionsRef]);
 
     useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
Fixes #2505 