### PR TITLE
fix(kit): `maskitoParseDate` should return `null` for invalid `Date` string

### DIFF
--- a/projects/kit/src/lib/masks/date/utils/parse-date.ts
+++ b/projects/kit/src/lib/masks/date/utils/parse-date.ts
@@ -6,7 +6,10 @@ export function maskitoParseDate(
     value: string,
     {mode, min = DEFAULT_MIN_DATE, max = DEFAULT_MAX_DATE}: MaskitoDateParams,
 ): Date | null {
-    if (value.length < mode.length) {
+    const digitsPattern = mode.replaceAll(/[^dmy]/g, '');
+    const digits = value.replaceAll(/\D+/g, '');
+
+    if (digits.length !== digitsPattern.length) {
         return null;
     }
 

--- a/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
+++ b/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
@@ -172,4 +172,26 @@ describe('maskitoParseDate', () => {
             expect(parsedDate?.getTime()).toBe(params.max?.getTime());
         });
     });
+
+    describe('invalid date strings', () => {
+        const params: MaskitoDateParams = {
+            mode: 'mm/dd/yyyy',
+            min: new Date('2000-01-01T00:00:00.000'),
+            max: new Date('2030-01-01T00:00:00.000'),
+        };
+
+        it.each([
+            'this-is-not-a-date',
+            '',
+            '   ',
+            '12//2020',
+            '/31/2020',
+            '12/31/',
+            '12/31/20',
+            '12/31/abcd',
+            '1a/31/2020',
+        ])('should return null for "%s"', (value) => {
+            expect(maskitoParseDate(value, params)).toBeNull();
+        });
+    });
 });


### PR DESCRIPTION
Fixes #2558
Fixes https://github.com/taiga-family/maskito/issues/2541