### PR TITLE
fix(kit): `maskitoParseDate` & `maskitoParseDateTime` supports parsing of dates in formats `mm/dd`, `dd/mm`

### DIFF
--- a/projects/kit/src/lib/masks/date-time/utils/parse-date-time.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/parse-date-time.ts
@@ -30,5 +30,5 @@ export function maskitoParseDateTime(
 
     const dateTime = new Date(Number(date) + time);
 
-    return clamp(dateTime, min, max);
+    return dateMode.includes('y') ? clamp(dateTime, min, max) : dateTime;
 }

--- a/projects/kit/src/lib/masks/date-time/utils/tests/parse-date-time.spec.ts
+++ b/projects/kit/src/lib/masks/date-time/utils/tests/parse-date-time.spec.ts
@@ -133,6 +133,26 @@ describe('maskitoParseDateTime', () => {
         ).toBeNull();
     });
 
+    it('parses date-time with dd/mm date mode without year', () => {
+        expect(
+            maskitoParseDateTime('25/12, 16:20', {
+                dateMode: 'dd/mm',
+                timeMode,
+                dateTimeSeparator,
+            })?.getTime(),
+        ).toBe(Date.parse('0000-12-25T16:20:00.000'));
+    });
+
+    it('parses date-time with mm/dd date mode without year', () => {
+        expect(
+            maskitoParseDateTime('12/25, 16:20', {
+                dateMode: 'mm/dd',
+                timeMode,
+                dateTimeSeparator,
+            })?.getTime(),
+        ).toBe(Date.parse('0000-12-25T16:20:00.000'));
+    });
+
     it('handles invalid date-time separator', () => {
         expect(
             maskitoParseDateTime('31/12/2018-16:20', {

--- a/projects/kit/src/lib/masks/date/utils/parse-date.ts
+++ b/projects/kit/src/lib/masks/date/utils/parse-date.ts
@@ -17,5 +17,5 @@ export function maskitoParseDate(
 
     const parsedDate = segmentsToDate(dateSegments);
 
-    return clamp(parsedDate, min, max);
+    return mode.includes('y') ? clamp(parsedDate, min, max) : parsedDate;
 }

--- a/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
+++ b/projects/kit/src/lib/masks/date/utils/tests/parse-date.spec.ts
@@ -173,6 +173,26 @@ describe('maskitoParseDate', () => {
         });
     });
 
+    describe('mode without year segment', () => {
+        it('should parse mm/dd and preserve month/day values', () => {
+            const parsedDate = maskitoParseDate('12/25', {
+                mode: 'mm/dd',
+                separator: '/',
+            });
+
+            expect(parsedDate?.getTime()).toBe(Date.parse('0000-12-25T00:00:00.000'));
+        });
+
+        it('should parse dd/mm and preserve day/month values', () => {
+            const parsedDate = maskitoParseDate('25/12', {
+                mode: 'dd/mm',
+                separator: '/',
+            });
+
+            expect(parsedDate?.getTime()).toBe(Date.parse('0000-12-25T00:00:00.000'));
+        });
+    });
+
     describe('invalid date strings', () => {
         const params: MaskitoDateParams = {
             mode: 'mm/dd/yyyy',


### PR DESCRIPTION
Fixes #2423