### PR TITLE
chore(kit): refactor to use `withTimeDefaults`

### DIFF
--- a/projects/kit/src/lib/masks/date-time/date-time-mask.ts
+++ b/projects/kit/src/lib/masks/date-time/date-time-mask.ts
@@ -1,10 +1,6 @@
 import {MASKITO_DEFAULT_OPTIONS, type MaskitoOptions} from '@maskito/core';
 
 import {
-    DEFAULT_TIME_SEGMENT_MAX_VALUES,
-    DEFAULT_TIME_SEGMENT_MIN_VALUES,
-} from '../../constants';
-import {
     createMeridiemSteppingPlugin,
     createTimeSegmentsSteppingPlugin,
 } from '../../plugins';
@@ -19,8 +15,8 @@ import {
     createZeroPlaceholdersPreprocessor,
     normalizeDatePreprocessor,
 } from '../../processors';
-import type {MaskitoTimeSegments} from '../../types';
 import {createTimeMaskExpression} from '../../utils/time';
+import {withTimeDefaults} from '../time/utils/with-time-defaults';
 import {DATE_TIME_SEPARATOR} from './constants';
 import type {MaskitoDateTimeParams} from './date-time-params';
 import {createMinMaxDateTimePostprocessor} from './postprocessors';
@@ -36,18 +32,11 @@ export function maskitoDateTimeOptionsGenerator({
     dateTimeSeparator = DATE_TIME_SEPARATOR,
     timeStep = 0,
 }: MaskitoDateTimeParams): Required<MaskitoOptions> {
-    const hasMeridiem = timeMode.includes('AA');
     const dateModeTemplate = dateMode.split('/').join(dateSeparator);
 
-    const timeSegmentMaxValues: MaskitoTimeSegments<number> = {
-        ...DEFAULT_TIME_SEGMENT_MAX_VALUES,
-        ...(hasMeridiem ? {hours: 12} : {}),
-    };
-
-    const timeSegmentMinValues: MaskitoTimeSegments<number> = {
-        ...DEFAULT_TIME_SEGMENT_MIN_VALUES,
-        ...(hasMeridiem ? {hours: 1} : {}),
-    };
+    const {timeSegmentMaxValues, timeSegmentMinValues} = withTimeDefaults({
+        mode: timeMode,
+    });
 
     const fullMode = `${dateModeTemplate}${dateTimeSeparator}${timeMode}`;
 

--- a/projects/kit/src/lib/masks/date-time/date-time-mask.ts
+++ b/projects/kit/src/lib/masks/date-time/date-time-mask.ts
@@ -88,6 +88,7 @@ export function maskitoDateTimeOptionsGenerator({
                 dateTimeSeparator,
                 timeMode,
                 timeSegmentMaxValues,
+                timeSeparators: separators,
             }),
         ],
         postprocessors: [

--- a/projects/kit/src/lib/masks/date-time/date-time-mask.ts
+++ b/projects/kit/src/lib/masks/date-time/date-time-mask.ts
@@ -34,7 +34,7 @@ export function maskitoDateTimeOptionsGenerator({
 }: MaskitoDateTimeParams): Required<MaskitoOptions> {
     const dateModeTemplate = dateMode.split('/').join(dateSeparator);
 
-    const {timeSegmentMaxValues, timeSegmentMinValues} = withTimeDefaults({
+    const {timeSegmentMaxValues, timeSegmentMinValues, separators} = withTimeDefaults({
         mode: timeMode,
     });
 
@@ -49,7 +49,7 @@ export function maskitoDateTimeOptionsGenerator({
             ...dateTimeSeparator.split(''),
             ...createTimeMaskExpression({
                 mode: timeMode,
-                separators: [],
+                separators,
             }),
         ],
         overwriteMode: 'replace',

--- a/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
+++ b/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
@@ -11,12 +11,14 @@ export function createValidDateTimePreprocessor({
     dateTimeSeparator,
     timeMode,
     timeSegmentMaxValues,
+    timeSeparators,
 }: {
     dateModeTemplate: string;
     dateSeparator: string;
     dateTimeSeparator: string;
     timeMode: MaskitoTimeMode;
     timeSegmentMaxValues: MaskitoTimeSegments<number>;
+    timeSeparators: readonly string[];
 }): MaskitoPreprocessor {
     return ({elementState, data}) => {
         const {value, selection} = elementState;
@@ -64,7 +66,7 @@ export function createValidDateTimePreprocessor({
 
         const updatedTimeState = enrichTimeSegmentsWithZeroes(
             {value: timeString, selection: [from, to]},
-            {mode: timeMode, timeSegmentMaxValues},
+            {mode: timeMode, separators: timeSeparators, timeSegmentMaxValues},
         );
 
         to = updatedTimeState.selection[1];

--- a/projects/kit/src/lib/masks/time/time-mask.ts
+++ b/projects/kit/src/lib/masks/time/time-mask.ts
@@ -1,10 +1,6 @@
 import type {MaskitoOptions} from '@maskito/core';
 
 import {
-    DEFAULT_TIME_SEGMENT_MAX_VALUES,
-    DEFAULT_TIME_SEGMENT_MIN_VALUES,
-} from '../../constants';
-import {
     createMeridiemSteppingPlugin,
     createTimeSegmentsSteppingPlugin,
 } from '../../plugins';
@@ -18,32 +14,22 @@ import {
     maskitoPostfixPostprocessorGenerator,
     maskitoPrefixPostprocessorGenerator,
 } from '../../processors';
-import type {MaskitoTimeSegments} from '../../types';
 import {createTimeMaskExpression, enrichTimeSegmentsWithZeroes} from '../../utils/time';
 import type {MaskitoTimeParams} from './time-params';
+import {withTimeDefaults} from './utils/with-time-defaults';
 
-export function maskitoTimeOptionsGenerator({
-    mode,
-    separators = [],
-    timeSegmentMaxValues = {},
-    timeSegmentMinValues = {},
-    step = 0,
-    prefix = '',
-    postfix = '',
-}: MaskitoTimeParams): Required<MaskitoOptions> {
-    const hasMeridiem = mode.includes('AA');
-
-    const enrichedTimeSegmentMaxValues: MaskitoTimeSegments<number> = {
-        ...DEFAULT_TIME_SEGMENT_MAX_VALUES,
-        ...(hasMeridiem ? {hours: 12} : {}),
-        ...timeSegmentMaxValues,
-    };
-
-    const enrichedTimeSegmentMinValues: MaskitoTimeSegments<number> = {
-        ...DEFAULT_TIME_SEGMENT_MIN_VALUES,
-        ...(hasMeridiem ? {hours: 1} : {}),
-        ...timeSegmentMinValues,
-    };
+export function maskitoTimeOptionsGenerator(
+    params: MaskitoTimeParams,
+): Required<MaskitoOptions> {
+    const {
+        mode,
+        separators,
+        prefix,
+        postfix,
+        timeSegmentMinValues,
+        timeSegmentMaxValues,
+        step,
+    } = withTimeDefaults(params);
 
     const maskExpression = [...prefix, ...createTimeMaskExpression({mode, separators})];
 
@@ -58,8 +44,8 @@ export function maskitoTimeOptionsGenerator({
             createMeridiemPreprocessor(mode),
             createInvalidTimeSegmentInsertionPreprocessor({
                 timeMode: mode,
-                timeSegmentMinValues: enrichedTimeSegmentMinValues,
-                timeSegmentMaxValues: enrichedTimeSegmentMaxValues,
+                timeSegmentMinValues,
+                timeSegmentMaxValues,
             }),
         ],
         postprocessors: [
@@ -67,7 +53,7 @@ export function maskitoTimeOptionsGenerator({
             (elementState) =>
                 enrichTimeSegmentsWithZeroes(elementState, {
                     mode,
-                    timeSegmentMaxValues: enrichedTimeSegmentMaxValues,
+                    timeSegmentMaxValues,
                     separators,
                 }),
             maskitoPrefixPostprocessorGenerator(prefix),
@@ -77,8 +63,8 @@ export function maskitoTimeOptionsGenerator({
             createTimeSegmentsSteppingPlugin({
                 fullMode: mode,
                 step,
-                timeSegmentMinValues: enrichedTimeSegmentMinValues,
-                timeSegmentMaxValues: enrichedTimeSegmentMaxValues,
+                timeSegmentMinValues,
+                timeSegmentMaxValues,
             }),
             createMeridiemSteppingPlugin(mode.indexOf('AA')),
         ],

--- a/projects/kit/src/lib/masks/time/utils/parse-time.ts
+++ b/projects/kit/src/lib/masks/time/utils/parse-time.ts
@@ -1,7 +1,6 @@
-import {DEFAULT_TIME_SEGMENT_MAX_VALUES} from '../../../constants';
-import type {MaskitoTimeSegments} from '../../../types';
 import {padStartTimeSegments, parseTimeString} from '../../../utils/time';
 import type {MaskitoTimeParams} from '../time-params';
+import {withTimeDefaults} from './with-time-defaults';
 
 /**
  * Converts a formatted time string to milliseconds based on the given `options.mode`.
@@ -9,18 +8,11 @@ import type {MaskitoTimeParams} from '../time-params';
  * @param maskedTime a formatted time string by {@link maskitoTimeOptionsGenerator} or {@link maskitoStringifyTime}
  * @param params
  */
-export function maskitoParseTime(
-    maskedTime: string,
-    {mode, timeSegmentMaxValues = {}}: MaskitoTimeParams,
-): number {
-    const maxValues: MaskitoTimeSegments<number> = {
-        ...DEFAULT_TIME_SEGMENT_MAX_VALUES,
-        ...timeSegmentMaxValues,
-    };
-
-    const msInSecond = maxValues.milliseconds + 1;
-    const msInMinute = (maxValues.seconds + 1) * msInSecond;
-    const msInHour = (maxValues.minutes + 1) * msInMinute;
+export function maskitoParseTime(maskedTime: string, params: MaskitoTimeParams): number {
+    const {mode, timeSegmentMaxValues} = withTimeDefaults(params);
+    const msInSecond = timeSegmentMaxValues.milliseconds + 1;
+    const msInMinute = (timeSegmentMaxValues.seconds + 1) * msInSecond;
+    const msInHour = (timeSegmentMaxValues.minutes + 1) * msInMinute;
     const parsedTime = padStartTimeSegments(parseTimeString(maskedTime, mode));
     let hours = Number(parsedTime.hours ?? '');
 

--- a/projects/kit/src/lib/masks/time/utils/stringify-time.ts
+++ b/projects/kit/src/lib/masks/time/utils/stringify-time.ts
@@ -1,7 +1,7 @@
-import {CHAR_NO_BREAK_SPACE, DEFAULT_TIME_SEGMENT_MAX_VALUES} from '../../../constants';
-import type {MaskitoTimeSegments} from '../../../types';
+import {CHAR_NO_BREAK_SPACE} from '../../../constants';
 import {padStartTimeSegments, toTimeString} from '../../../utils/time';
 import type {MaskitoTimeParams} from '../time-params';
+import {withTimeDefaults} from './with-time-defaults';
 
 /**
  * Converts milliseconds to a formatted time string based on the given `options.mode`.
@@ -11,17 +11,13 @@ import type {MaskitoTimeParams} from '../time-params';
  */
 export function maskitoStringifyTime(
     milliseconds: number,
-    {mode, separators = [], timeSegmentMaxValues = {}}: MaskitoTimeParams,
+    params: MaskitoTimeParams,
 ): string {
-    const maxValues: MaskitoTimeSegments<number> = {
-        ...DEFAULT_TIME_SEGMENT_MAX_VALUES,
-        ...timeSegmentMaxValues,
-    };
-
+    const {mode, separators, timeSegmentMaxValues} = withTimeDefaults(params);
     const hasMeridiem = mode.includes('AA');
-    const msInSecond = maxValues.milliseconds + 1;
-    const msInMinute = (maxValues.seconds + 1) * msInSecond;
-    const msInHour = (maxValues.minutes + 1) * msInMinute;
+    const msInSecond = timeSegmentMaxValues.milliseconds + 1;
+    const msInMinute = (timeSegmentMaxValues.seconds + 1) * msInSecond;
+    const msInHour = (timeSegmentMaxValues.minutes + 1) * msInMinute;
     const hours = Math.trunc(milliseconds / msInHour);
 
     milliseconds -= hours * msInHour;

--- a/projects/kit/src/lib/masks/time/utils/tests/with-time-defaults.spec.ts
+++ b/projects/kit/src/lib/masks/time/utils/tests/with-time-defaults.spec.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from '@jest/globals';
+
+import {withTimeDefaults} from '../with-time-defaults';
+
+describe('withTimeDefaults', () => {
+    describe('separators resolution', () => {
+        it('fills missing positions with canonical separators from mode', () => {
+            expect(
+                withTimeDefaults({mode: 'HH:MM:SS.MSS', separators: []}).separators,
+            ).toEqual([':', ':', '.']);
+        });
+
+        it('falls back per-position when user array is shorter than mode', () => {
+            expect(
+                withTimeDefaults({mode: 'HH:MM:SS.MSS', separators: ['.']}).separators,
+            ).toEqual(['.', ':', '.']);
+        });
+
+        it('uses user-provided separators when array fully covers mode', () => {
+            expect(
+                withTimeDefaults({
+                    mode: 'HH:MM:SS',
+                    separators: [' h ', ' min '],
+                }).separators,
+            ).toEqual([' h ', ' min ']);
+        });
+
+        it('defaults to canonical separators when no separators provided', () => {
+            expect(withTimeDefaults({mode: 'HH:MM:SS.MSS'}).separators).toEqual([
+                ':',
+                ':',
+                '.',
+            ]);
+        });
+
+        it('ignores meridiem part when computing canonical separators', () => {
+            expect(withTimeDefaults({mode: 'HH:MM AA'}).separators).toEqual([':']);
+        });
+
+        it('returns empty array for mode without any separator slot', () => {
+            expect(withTimeDefaults({mode: 'HH'}).separators).toEqual([]);
+            expect(withTimeDefaults({mode: 'HH AA'}).separators).toEqual([]);
+        });
+    });
+});

--- a/projects/kit/src/lib/masks/time/utils/with-time-defaults.ts
+++ b/projects/kit/src/lib/masks/time/utils/with-time-defaults.ts
@@ -1,0 +1,36 @@
+import {
+    DEFAULT_TIME_SEGMENT_MAX_VALUES,
+    DEFAULT_TIME_SEGMENT_MIN_VALUES,
+} from '../../../constants';
+import {type MaskitoTimeParams} from '../time-params';
+
+export function withTimeDefaults({
+    mode,
+    timeSegmentMaxValues = {},
+    timeSegmentMinValues = {},
+    ...params
+}: MaskitoTimeParams): Required<MaskitoTimeParams> & {
+    timeSegmentMaxValues: Required<MaskitoTimeParams['timeSegmentMaxValues']>;
+    timeSegmentMinValues: Required<MaskitoTimeParams['timeSegmentMinValues']>;
+} {
+    const hasMeridiem = mode.includes('AA');
+
+    return {
+        mode,
+        step: 0,
+        prefix: '',
+        postfix: '',
+        separators: [],
+        ...params,
+        timeSegmentMinValues: {
+            ...DEFAULT_TIME_SEGMENT_MIN_VALUES,
+            ...(hasMeridiem ? {hours: 1} : {}),
+            ...timeSegmentMinValues,
+        },
+        timeSegmentMaxValues: {
+            ...DEFAULT_TIME_SEGMENT_MAX_VALUES,
+            ...(hasMeridiem ? {hours: 12} : {}),
+            ...timeSegmentMaxValues,
+        },
+    };
+}

--- a/projects/kit/src/lib/masks/time/utils/with-time-defaults.ts
+++ b/projects/kit/src/lib/masks/time/utils/with-time-defaults.ts
@@ -1,11 +1,13 @@
 import {
     DEFAULT_TIME_SEGMENT_MAX_VALUES,
     DEFAULT_TIME_SEGMENT_MIN_VALUES,
+    TIME_FIXED_CHARACTERS,
 } from '../../../constants';
 import {type MaskitoTimeParams} from '../time-params';
 
 export function withTimeDefaults({
     mode,
+    separators,
     timeSegmentMaxValues = {},
     timeSegmentMinValues = {},
     ...params
@@ -15,13 +17,17 @@ export function withTimeDefaults({
 } {
     const hasMeridiem = mode.includes('AA');
 
+    const defaultSeparators = Array.from(mode.replace(' AA', '')).filter((char) =>
+        TIME_FIXED_CHARACTERS.includes(char),
+    );
+
     return {
         mode,
         step: 0,
         prefix: '',
         postfix: '',
-        separators: [],
         ...params,
+        separators: defaultSeparators.map((fallback, i) => separators?.[i] ?? fallback),
         timeSegmentMinValues: {
             ...DEFAULT_TIME_SEGMENT_MIN_VALUES,
             ...(hasMeridiem ? {hours: 1} : {}),

--- a/projects/kit/src/lib/utils/time/create-time-mask-expression.ts
+++ b/projects/kit/src/lib/utils/time/create-time-mask-expression.ts
@@ -12,7 +12,7 @@ export function createTimeMaskExpression({
     return Array.from(mode.replace(' AA', ''))
         .flatMap<RegExp | string>((char) =>
             TIME_FIXED_CHARACTERS.includes(char)
-                ? Array.from(separators[separatorIndex++] ?? char)
+                ? Array.from(separators[separatorIndex++]!)
                 : [/\d/],
         )
         .concat(mode.includes('AA') ? [CHAR_NO_BREAK_SPACE, /[AP]/i, /M/i] : []);

--- a/projects/kit/src/lib/utils/time/enrich-time-segments-with-zeroes.ts
+++ b/projects/kit/src/lib/utils/time/enrich-time-segments-with-zeroes.ts
@@ -16,9 +16,9 @@ export function enrichTimeSegmentsWithZeroes(
     {value, selection}: {value: string; selection: readonly [number, number]},
     {
         mode,
+        separators,
         timeSegmentMaxValues = DEFAULT_TIME_SEGMENT_MAX_VALUES,
-        separators = [],
-    }: Pick<MaskitoTimeParams, 'mode' | 'separators'> & {
+    }: Pick<Required<MaskitoTimeParams>, 'mode' | 'separators'> & {
         readonly timeSegmentMaxValues?: MaskitoTimeSegments<number>;
     },
 ): {value: string; selection: readonly [number, number]} {

--- a/projects/kit/src/lib/utils/time/tests/enrich-time-segments-with-zeroes.spec.ts
+++ b/projects/kit/src/lib/utils/time/tests/enrich-time-segments-with-zeroes.spec.ts
@@ -4,8 +4,10 @@ import {enrichTimeSegmentsWithZeroes} from '../enrich-time-segments-with-zeroes'
 
 describe('enrichTimeSegmentsWithZeroes', () => {
     const fn = (value: string): string =>
-        enrichTimeSegmentsWithZeroes({value, selection: [0, 0]}, {mode: 'HH:MM:SS'})
-            .value;
+        enrichTimeSegmentsWithZeroes(
+            {value, selection: [0, 0]},
+            {mode: 'HH:MM:SS', separators: [':', ':']},
+        ).value;
 
     it('all time segments valid', () => {
         expect(fn('17:43:00')).toBe('17:43:00');

--- a/projects/kit/src/lib/utils/time/tests/to-time-string.spec.ts
+++ b/projects/kit/src/lib/utils/time/tests/to-time-string.spec.ts
@@ -8,7 +8,7 @@ describe('toTimeString', () => {
             expect(
                 toTimeString(
                     {hours: '14', minutes: '30'},
-                    {mode: 'HH:MM', separators: []},
+                    {mode: 'HH:MM', separators: [':']},
                 ),
             ).toBe('14:30');
         });
@@ -17,7 +17,7 @@ describe('toTimeString', () => {
             expect(
                 toTimeString(
                     {hours: '14', minutes: '30', seconds: '45'},
-                    {mode: 'HH:MM:SS', separators: []},
+                    {mode: 'HH:MM:SS', separators: [':', ':']},
                 ),
             ).toBe('14:30:45');
         });
@@ -26,7 +26,7 @@ describe('toTimeString', () => {
             expect(
                 toTimeString(
                     {hours: '14', minutes: '30', seconds: '45', milliseconds: '678'},
-                    {mode: 'HH:MM:SS.MSS', separators: []},
+                    {mode: 'HH:MM:SS.MSS', separators: [':', ':', '.']},
                 ),
             ).toBe('14:30:45.678');
         });
@@ -35,7 +35,7 @@ describe('toTimeString', () => {
             expect(
                 toTimeString(
                     {minutes: '30', seconds: '45'},
-                    {mode: 'MM:SS', separators: []},
+                    {mode: 'MM:SS', separators: [':']},
                 ),
             ).toBe('30:45');
         });
@@ -44,7 +44,7 @@ describe('toTimeString', () => {
             expect(
                 toTimeString(
                     {seconds: '45', milliseconds: '678'},
-                    {mode: 'SS.MSS', separators: []},
+                    {mode: 'SS.MSS', separators: ['.']},
                 ),
             ).toBe('45.678');
         });
@@ -59,7 +59,7 @@ describe('toTimeString', () => {
             expect(
                 toTimeString(
                     {hours: '02', minutes: '30'},
-                    {mode: 'HH:MM AA', separators: []},
+                    {mode: 'HH:MM AA', separators: [':']},
                 ),
             ).toBe('02:30');
         });
@@ -101,24 +101,6 @@ describe('toTimeString', () => {
                 ),
             ).toBe('18 h 05 min 05,766');
         });
-
-        it('short array falls back to canonical separators from mode for remaining positions', () => {
-            expect(
-                toTimeString(
-                    {hours: '14', minutes: '30', seconds: '45'},
-                    {mode: 'HH:MM:SS', separators: ['.']},
-                ),
-            ).toBe('14.30:45');
-        });
-
-        it('short array falls back to canonical separators from mode for HH:MM:SS.MSS', () => {
-            expect(
-                toTimeString(
-                    {hours: '14', minutes: '30', seconds: '45', milliseconds: '678'},
-                    {mode: 'HH:MM:SS.MSS', separators: ['.']},
-                ),
-            ).toBe('14.30:45.678');
-        });
     });
 
     describe('partial segments (leading/trailing separator trimming)', () => {
@@ -126,15 +108,15 @@ describe('toTimeString', () => {
             expect(
                 toTimeString(
                     {hours: '14', minutes: '30'},
-                    {mode: 'HH:MM:SS', separators: []},
+                    {mode: 'HH:MM:SS', separators: [':', ':']},
                 ),
             ).toBe('14:30');
         });
 
         it('trims leading separator when hours are absent in MM:SS mode', () => {
-            expect(toTimeString({minutes: '05'}, {mode: 'MM:SS', separators: []})).toBe(
-                '05',
-            );
+            expect(
+                toTimeString({minutes: '05'}, {mode: 'MM:SS', separators: [':']}),
+            ).toBe('05');
         });
 
         it('trims fr-CA separator when minutes segment is absent', () => {

--- a/projects/kit/src/lib/utils/time/to-time-string.ts
+++ b/projects/kit/src/lib/utils/time/to-time-string.ts
@@ -3,13 +3,13 @@ import type {MaskitoTimeSegments} from '../../types';
 
 export function toTimeString(
     segments: Partial<MaskitoTimeSegments>,
-    {mode, separators = []}: Pick<MaskitoTimeParams, 'mode' | 'separators'>,
+    {mode, separators}: Pick<Required<MaskitoTimeParams>, 'mode' | 'separators'>,
 ): string {
     let separatorIndex = 0;
 
     const modeTemplate = mode
         .replace(' AA', '')
-        .replaceAll(/[:.]/g, (char) => separators[separatorIndex++] ?? char);
+        .replaceAll(/[:.]/g, () => separators[separatorIndex++]!);
 
     return modeTemplate
         .replaceAll(/H+/g, segments.hours ?? '')


### PR DESCRIPTION
Similar to already existing 
https://github.com/taiga-family/maskito/blob/f12a5f39eba69bd9a2bbcc869cad5cab8e4da984/projects/kit/src/lib/masks/number/utils/with-number-defaults.ts#L12