### PR TITLE
chore(release): v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+### [5.3.0](https://github.com/taiga-family/maskito/compare/v5.2.2...v5.3.0) (2026-06-04)
+
+### 🚀 Features
+
+- **kit**: add `maskitoDateTime` with new `locale` parameter
+  ([#2750](https://github.com/taiga-family/maskito/pull/2750))
+  [(9688aff)](https://github.com/taiga-family/maskito/commit/9688affa5eebd45ef7e67e77ae750793f9516831)
+- **kit**: add `maskitoTime` with new `locale` & `dayPeriod` parameters
+  ([#2741](https://github.com/taiga-family/maskito/pull/2741))
+  [(21281da)](https://github.com/taiga-family/maskito/commit/21281dadbc3b3d67ba3d22368e9dd0cfeadd437b)
+- **kit**: `Time` supports customization of separators ([#2675](https://github.com/taiga-family/maskito/pull/2675))
+  [(6f88fa0)](https://github.com/taiga-family/maskito/commit/6f88fa06d7b7a84c2e1bae7468309c7d43e3f4c8)
+- **kit**: add `maskitoDateRange` with new `locale` parameter
+  ([#2673](https://github.com/taiga-family/maskito/pull/2673))
+  [(4ed064b)](https://github.com/taiga-family/maskito/commit/4ed064bac37cda471499f858fa02bbad60bf3cea)
+- **kit**: add `maskitoDate` with new `locale` parameter ([#2666](https://github.com/taiga-family/maskito/pull/2666))
+  [(714edac)](https://github.com/taiga-family/maskito/commit/714edac5b42b518937ecf42ebb7d31c140ed8e83)
+- **kit**: add `maskitoNumber` with new `locale` parameter ([#2665](https://github.com/taiga-family/maskito/pull/2665))
+  [(d78b72b)](https://github.com/taiga-family/maskito/commit/d78b72bec4852abeddd485d37fa88a2ab1130bcf)
+
+### 🐞 Bug Fixes
+
+- **kit**: `maskitoParseTime` should pad incomplete time segments with leading zeros
+  ([#2726](https://github.com/taiga-family/maskito/pull/2726))
+  [(e0b77d2)](https://github.com/taiga-family/maskito/commit/e0b77d2835f2798ee226f879db7b08270ac84c7b)
+
 ### [5.2.2](https://github.com/taiga-family/maskito/compare/v5.2.1...v5.2.2) (2026-03-31)
 
 ### 🐞 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "maskito",
-    "version": "5.2.2",
+    "version": "5.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "maskito",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "license": "Apache-2.0",
             "workspaces": [
                 "projects/*"
@@ -53557,7 +53557,7 @@
         },
         "projects/angular": {
             "name": "@maskito/angular",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "2.8.1"
@@ -53574,7 +53574,7 @@
         },
         "projects/core": {
             "name": "@maskito/core",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "license": "Apache-2.0"
         },
         "projects/demo": {
@@ -53590,9 +53590,9 @@
                 "@angular/platform-server": "19.2.22",
                 "@angular/router": "19.2.22",
                 "@angular/ssr": "19.2.26",
-                "@maskito/angular": "*",
-                "@maskito/core": "*",
-                "@maskito/kit": "*",
+                "@maskito/angular": "^5.3.0",
+                "@maskito/core": "^5.3.0",
+                "@maskito/kit": "^5.3.0",
                 "@ng-web-apis/common": "5.3.0",
                 "@ng-web-apis/universal": "5.3.0",
                 "@stackblitz/sdk": "1.11.0",
@@ -53627,7 +53627,7 @@
         },
         "projects/kit": {
             "name": "@maskito/kit",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@maskito/core": "^5.2.2"
@@ -53635,7 +53635,7 @@
         },
         "projects/phone": {
             "name": "@maskito/phone",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "libphonenumber-js": "1.13.2"
@@ -53648,7 +53648,7 @@
         },
         "projects/react": {
             "name": "@maskito/react",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@testing-library/react": "16.3.2",
@@ -53667,7 +53667,7 @@
         },
         "projects/vue": {
             "name": "@maskito/vue",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@vue/test-utils": "2.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maskito",
-    "version": "5.2.2",
+    "version": "5.3.0",
     "description": "Collection of libraries to create an input mask which ensures that user types value according to predefined format",
     "homepage": "https://maskito.dev",
     "bugs": "https://github.com/taiga-family/maskito/issues",

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maskito/angular",
-    "version": "5.2.2",
+    "version": "5.3.0",
     "description": "The Angular-specific Maskito's library",
     "keywords": [
         "input",
@@ -53,7 +53,7 @@
     "peerDependencies": {
         "@angular/core": ">=19.0.0",
         "@angular/forms": ">=19.0.0",
-        "@maskito/core": "^5.2.2"
+        "@maskito/core": "^5.3.0"
     },
     "ng-update": {
         "packageGroup": [

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maskito/core",
-    "version": "5.2.2",
+    "version": "5.3.0",
     "description": "The main zero-dependency and framework-agnostic Maskito's package to create an input mask",
     "keywords": [
         "input",

--- a/projects/kit/package.json
+++ b/projects/kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maskito/kit",
-    "version": "5.2.2",
+    "version": "5.3.0",
     "description": "The optional framework-agnostic Maskito's package with ready-to-use masks",
     "keywords": [
         "input",
@@ -45,6 +45,6 @@
         }
     ],
     "peerDependencies": {
-        "@maskito/core": "^5.2.2"
+        "@maskito/core": "^5.3.0"
     }
 }

--- a/projects/phone/package.json
+++ b/projects/phone/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maskito/phone",
-    "version": "5.2.2",
+    "version": "5.3.0",
     "description": "The optional framework-agnostic Maskito's package with phone masks",
     "keywords": [
         "input",
@@ -50,8 +50,8 @@
         "libphonenumber-js": "1.13.2"
     },
     "peerDependencies": {
-        "@maskito/core": "^5.2.2",
-        "@maskito/kit": "^5.2.2",
+        "@maskito/core": "^5.3.0",
+        "@maskito/kit": "^5.3.0",
         "libphonenumber-js": ">=1.0.0"
     }
 }

--- a/projects/react/package.json
+++ b/projects/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maskito/react",
-    "version": "5.2.2",
+    "version": "5.3.0",
     "description": "The React-specific Maskito's library",
     "keywords": [
         "input",
@@ -53,7 +53,7 @@
         "react-test-renderer": "19.2.6"
     },
     "peerDependencies": {
-        "@maskito/core": "^5.2.2",
+        "@maskito/core": "^5.3.0",
         "react": ">=16.8",
         "react-dom": ">=16.8"
     }

--- a/projects/vue/package.json
+++ b/projects/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maskito/vue",
-    "version": "5.2.2",
+    "version": "5.3.0",
     "description": "The Vue-specific Maskito's library",
     "keywords": [
         "input",
@@ -49,7 +49,7 @@
         "vue": "3.5.33"
     },
     "peerDependencies": {
-        "@maskito/core": "^5.2.2",
+        "@maskito/core": "^5.3.0",
         "vue": ">=3.0.0"
     }
 }


### PR DESCRIPTION
Manually release it because [CI-job](https://github.com/taiga-family/maskito/actions/runs/26944747955/job/79494811874) fails with

```
❌ > nx run angular:publish
✅ > nx run core:build
✅ > nx run angular:build:production
✅ > nx run react:build
✅ > nx run kit:build
✅ > nx run vue:build
✅ > nx run core:publish
✅ > nx run phone:build
✅ > nx run kit:publish
✅ > nx run react:publish
✅ > nx run vue:publish
✅ > nx run phone:publish
❌ > nx run angular:publish
  
  > npm publish ./dist/angular --ignore-scripts
  
  npm error code E403
  npm error 403 403 Forbidden - PUT https://registry.npmjs.org/@maskito%2fangular - You cannot publish over the previously published versions: 5.3.0.
  npm error 403 In most cases, you or one of your dependencies are requesting a package version that is forbidden by your security policy, or on a server you do not have access to.
  npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-06-04T10_00_53_014Z-debug-0.log
  Warning: command "npm publish ./dist/angular --ignore-scripts" exited with non-zero status code::endgroup::
  
  
   NX   Running target publish for 6 projects and 6 tasks they depend on failed
  
  Failed tasks:
  
  - angular:publish
  Error: Process completed with exit code 1.
```

But actually `@maskito/angular@5.3.0` was released

https://www.npmjs.com/package/@maskito/angular/v/5.3.0