### PR TITLE
fix(kit): `Time` with meridiem should toggle AM/PM on stepping

### DIFF
--- a/projects/demo-integrations/src/tests/component-testing/time/time-stepping.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/time/time-stepping.cy.ts
@@ -1,0 +1,129 @@
+import {maskitoTime, type MaskitoTimeParams} from '@maskito/kit';
+
+import {TestInput} from '../utils';
+
+function mount(params: MaskitoTimeParams): void {
+    cy.mount(TestInput, {componentProperties: {maskitoOptions: maskitoTime(params)}});
+}
+
+describe('Time | hour stepping toggles custom dayPeriod marker', () => {
+    describe("['上午', '下午'] Chinese", () => {
+        beforeEach(() => {
+            mount({mode: 'HH:MM', dayPeriod: ['上午', '下午'], step: 1});
+        });
+
+        it('11:00 上午 + ArrowUp on hour --- 12:00 下午', () => {
+            cy.get('input')
+                .type('1100上')
+                .should('have.value', '11:00 上午')
+                .type('{moveToStart}{rightArrow}')
+                .type('{upArrow}')
+                .should('have.value', '12:00 下午');
+        });
+
+        it('12:00 下午 + ArrowDown on hour --- 11:00 上午', () => {
+            cy.get('input')
+                .type('1200下')
+                .should('have.value', '12:00 下午')
+                .type('{moveToStart}{rightArrow}')
+                .type('{downArrow}')
+                .should('have.value', '11:00 上午');
+        });
+
+        it('12:00 上午 + ArrowUp on hour --- 01:00 上午', () => {
+            cy.get('input')
+                .type('1200上')
+                .should('have.value', '12:00 上午')
+                .type('{moveToStart}{rightArrow}')
+                .type('{upArrow}')
+                .should('have.value', '01:00 上午');
+        });
+
+        it('12:00 下午 + ArrowUp on hour --- 01:00 下午', () => {
+            cy.get('input')
+                .type('1200下')
+                .should('have.value', '12:00 下午')
+                .type('{moveToStart}{rightArrow}')
+                .type('{upArrow}')
+                .should('have.value', '01:00 下午');
+        });
+
+        it('01:00 上午 + ArrowDown on hour --- 12:00 上午', () => {
+            cy.get('input')
+                .type('0100上')
+                .should('have.value', '01:00 上午')
+                .type('{moveToStart}{rightArrow}')
+                .type('{downArrow}')
+                .should('have.value', '12:00 上午');
+        });
+
+        it('01:00 下午 + ArrowDown on hour --- 12:00 下午', () => {
+            cy.get('input')
+                .type('0100下')
+                .should('have.value', '01:00 下午')
+                .type('{moveToStart}{rightArrow}')
+                .type('{downArrow}')
+                .should('have.value', '12:00 下午');
+        });
+    });
+
+    describe("['am', 'pm'] lowercase (hi-IN style)", () => {
+        beforeEach(() => {
+            mount({mode: 'HH:MM', dayPeriod: ['am', 'pm'], step: 1});
+        });
+
+        it('11:00 am + ArrowUp on hour --- 12:00 pm', () => {
+            cy.get('input')
+                .type('1100a')
+                .should('have.value', '11:00 am')
+                .type('{moveToStart}{rightArrow}')
+                .type('{upArrow}')
+                .should('have.value', '12:00 pm');
+        });
+
+        it('11:00 pm + ArrowUp on hour --- 12:00 am', () => {
+            cy.get('input')
+                .type('1100p')
+                .should('have.value', '11:00 pm')
+                .type('{moveToStart}{rightArrow}')
+                .type('{upArrow}')
+                .should('have.value', '12:00 am');
+        });
+
+        it('12:00 am + ArrowUp on hour --- 01:00 am', () => {
+            cy.get('input')
+                .type('1200a')
+                .should('have.value', '12:00 am')
+                .type('{moveToStart}{rightArrow}')
+                .type('{upArrow}')
+                .should('have.value', '01:00 am');
+        });
+
+        it('12:00 pm + ArrowUp on hour --- 01:00 pm', () => {
+            cy.get('input')
+                .type('1200p')
+                .should('have.value', '12:00 pm')
+                .type('{moveToStart}{rightArrow}')
+                .type('{upArrow}')
+                .should('have.value', '01:00 pm');
+        });
+
+        it('01:00 am + ArrowDown on hour --- 12:00 am', () => {
+            cy.get('input')
+                .type('0100a')
+                .should('have.value', '01:00 am')
+                .type('{moveToStart}{rightArrow}')
+                .type('{downArrow}')
+                .should('have.value', '12:00 am');
+        });
+
+        it('01:00 pm + ArrowDown on hour --- 12:00 pm', () => {
+            cy.get('input')
+                .type('0100p')
+                .should('have.value', '01:00 pm')
+                .type('{moveToStart}{rightArrow}')
+                .type('{downArrow}')
+                .should('have.value', '12:00 pm');
+        });
+    });
+});

--- a/projects/demo-integrations/src/tests/kit/date-time/date-time-time-step.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date-time/date-time-time-step.cy.ts
@@ -147,6 +147,7 @@ describe('DateTime | timeStep', () => {
             });
         });
     });
+
     describe('yy/mm;HH:MM AA', () => {
         describe('timeStep = 1, initial state = 22/12;', () => {
             beforeEach(() => {
@@ -182,7 +183,149 @@ describe('DateTime | timeStep', () => {
                     .type('{downArrow}'.repeat(4))
                     .should('have.a.prop', 'selectionStart', '22.12;'.length)
                     .should('have.a.prop', 'selectionEnd', '22.12;'.length)
-                    .should('have.value', '22.12;10:34 PM');
+                    .should('have.value', '22.12;10:34 AM');
+            });
+
+            describe('meridiem toggling when hour crosses 12-hour boundary', () => {
+                const PREFIX = '22.12;';
+
+                [
+                    // 11 ↑ 12 toggles the day period (12 AM = midnight, 12 PM = noon)
+                    {
+                        typed: '1100p',
+                        time: '11:00 PM',
+                        hourCaret: 0,
+                        newTime: '12:00 AM',
+                    },
+                    {
+                        typed: '1100p',
+                        time: '11:00 PM',
+                        hourCaret: 1,
+                        newTime: '12:00 AM',
+                    },
+                    {
+                        typed: '1100p',
+                        time: '11:00 PM',
+                        hourCaret: 2,
+                        newTime: '12:00 AM',
+                    },
+                    {
+                        typed: '1100a',
+                        time: '11:00 AM',
+                        hourCaret: 0,
+                        newTime: '12:00 PM',
+                    },
+                    {
+                        typed: '1100a',
+                        time: '11:00 AM',
+                        hourCaret: 1,
+                        newTime: '12:00 PM',
+                    },
+                    {
+                        typed: '1100a',
+                        time: '11:00 AM',
+                        hourCaret: 2,
+                        newTime: '12:00 PM',
+                    },
+
+                    // 12 ↑ 01 stays within the same day period
+                    {
+                        typed: '1200a',
+                        time: '12:00 AM',
+                        hourCaret: 0,
+                        newTime: '01:00 AM',
+                    },
+                    {
+                        typed: '1200p',
+                        time: '12:00 PM',
+                        hourCaret: 0,
+                        newTime: '01:00 PM',
+                    },
+                ].forEach(({typed, time, hourCaret, newTime}) => {
+                    const value = `${PREFIX}${time}`;
+                    const newValue = `${PREFIX}${newTime}`;
+                    const caretIndex = PREFIX.length + hourCaret;
+
+                    it(`${value} (caret ${caretIndex}) --- ↑ --- ${newValue}`, () => {
+                        cy.get('@input')
+                            .type(typed)
+                            .should('have.value', value)
+                            .type(`{moveToStart}${'{rightArrow}'.repeat(caretIndex)}`)
+                            .type('{upArrow}')
+                            .should('have.value', newValue)
+                            .should('have.a.prop', 'selectionStart', caretIndex)
+                            .should('have.a.prop', 'selectionEnd', caretIndex);
+                    });
+                });
+
+                [
+                    // 12 ↓ 11 toggles the day period
+                    {
+                        typed: '1200a',
+                        time: '12:00 AM',
+                        hourCaret: 0,
+                        newTime: '11:00 PM',
+                    },
+                    {
+                        typed: '1200a',
+                        time: '12:00 AM',
+                        hourCaret: 1,
+                        newTime: '11:00 PM',
+                    },
+                    {
+                        typed: '1200a',
+                        time: '12:00 AM',
+                        hourCaret: 2,
+                        newTime: '11:00 PM',
+                    },
+                    {
+                        typed: '1200p',
+                        time: '12:00 PM',
+                        hourCaret: 0,
+                        newTime: '11:00 AM',
+                    },
+                    {
+                        typed: '1200p',
+                        time: '12:00 PM',
+                        hourCaret: 1,
+                        newTime: '11:00 AM',
+                    },
+                    {
+                        typed: '1200p',
+                        time: '12:00 PM',
+                        hourCaret: 2,
+                        newTime: '11:00 AM',
+                    },
+
+                    // 01 ↓ 12 stays within the same day period
+                    {
+                        typed: '0100a',
+                        time: '01:00 AM',
+                        hourCaret: 0,
+                        newTime: '12:00 AM',
+                    },
+                    {
+                        typed: '0100p',
+                        time: '01:00 PM',
+                        hourCaret: 0,
+                        newTime: '12:00 PM',
+                    },
+                ].forEach(({typed, time, hourCaret, newTime}) => {
+                    const value = `${PREFIX}${time}`;
+                    const newValue = `${PREFIX}${newTime}`;
+                    const caretIndex = PREFIX.length + hourCaret;
+
+                    it(`${value} (caret ${caretIndex}) --- ↓ --- ${newValue}`, () => {
+                        cy.get('@input')
+                            .type(typed)
+                            .should('have.value', value)
+                            .type(`{moveToStart}${'{rightArrow}'.repeat(caretIndex)}`)
+                            .type('{downArrow}')
+                            .should('have.value', newValue)
+                            .should('have.a.prop', 'selectionStart', caretIndex)
+                            .should('have.a.prop', 'selectionEnd', caretIndex);
+                    });
+                });
             });
 
             it('increments and decrements minutes in AM/PM mode correctly', () => {

--- a/projects/demo-integrations/src/tests/kit/time/time-step.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/time/time-step.cy.ts
@@ -91,6 +91,14 @@ describe('Time', () => {
                         .should('have.a.prop', 'selectionStart', 2)
                         .should('have.a.prop', 'selectionEnd', 2);
                 });
+
+                it('does not append AM/PM when mode has no day-period (HH:MM, hour 11 -> 12)', () => {
+                    cy.get('@input')
+                        .type('11')
+                        .type('{leftArrow}'.repeat(2))
+                        .type('{upArrow}')
+                        .should('have.value', '12');
+                });
             });
 
             describe('step = 0', () => {
@@ -134,11 +142,26 @@ describe('Time', () => {
                 describe('time segment digits stepping', () => {
                     [
                         {value: '12:34 AM', caretIndex: 0, newValue: '01:34 AM'},
-                        {value: '12:34 AM', caretIndex: '1'.length, newValue: '01:34 AM'},
+                        {
+                            value: '12:34 AM',
+                            caretIndex: '1'.length,
+                            newValue: '01:34 AM',
+                        },
                         {
                             value: '12:34 AM',
                             caretIndex: '12'.length,
                             newValue: '01:34 AM',
+                        },
+                        {value: '12:34 PM', caretIndex: 0, newValue: '01:34 PM'},
+                        {
+                            value: '12:34 PM',
+                            caretIndex: '1'.length,
+                            newValue: '01:34 PM',
+                        },
+                        {
+                            value: '12:34 PM',
+                            caretIndex: '12'.length,
+                            newValue: '01:34 PM',
                         },
                         {
                             value: '12:34 AM',
@@ -168,12 +191,38 @@ describe('Time', () => {
                     });
 
                     [
-                        {value: '12:34 PM', caretIndex: 0, newValue: '11:34 PM'},
-                        {value: '12:34 PM', caretIndex: '1'.length, newValue: '11:34 PM'},
+                        {value: '12:34 PM', caretIndex: 0, newValue: '11:34 AM'},
+                        {
+                            value: '12:34 PM',
+                            caretIndex: '1'.length,
+                            newValue: '11:34 AM',
+                        },
                         {
                             value: '12:34 PM',
                             caretIndex: '12'.length,
-                            newValue: '11:34 PM',
+                            newValue: '11:34 AM',
+                        },
+                        {value: '01:34 AM', caretIndex: 0, newValue: '12:34 AM'},
+                        {
+                            value: '01:34 AM',
+                            caretIndex: '0'.length,
+                            newValue: '12:34 AM',
+                        },
+                        {
+                            value: '01:34 AM',
+                            caretIndex: '01'.length,
+                            newValue: '12:34 AM',
+                        },
+                        {value: '01:34 PM', caretIndex: 0, newValue: '12:34 PM'},
+                        {
+                            value: '01:34 PM',
+                            caretIndex: '0'.length,
+                            newValue: '12:34 PM',
+                        },
+                        {
+                            value: '01:34 PM',
+                            caretIndex: '01'.length,
+                            newValue: '12:34 PM',
                         },
                         {
                             value: '12:34 PM',
@@ -199,6 +248,38 @@ describe('Time', () => {
                                 .should('have.value', newValue)
                                 .should('have.a.prop', 'selectionStart', caretIndex)
                                 .should('have.a.prop', 'selectionEnd', caretIndex);
+                        });
+                    });
+                });
+
+                describe('hour stepping across 11/12 boundary toggles meridiem', () => {
+                    [
+                        {value: '11:00 AM', newValue: '12:00 PM'},
+                        {value: '11:00 PM', newValue: '12:00 AM'},
+                    ].forEach(({value, newValue}) => {
+                        it(`${withCaretLabel(value, '1'.length)} --- ↑ --- ${withCaretLabel(newValue, '1'.length)}`, () => {
+                            cy.get('@textfield')
+                                .type(value)
+                                .type(`{moveToStart}${'{rightArrow}'.repeat('1'.length)}`)
+                                .type('{upArrow}')
+                                .should('have.value', newValue)
+                                .should('have.a.prop', 'selectionStart', '1'.length)
+                                .should('have.a.prop', 'selectionEnd', '1'.length);
+                        });
+                    });
+
+                    [
+                        {value: '12:00 AM', newValue: '11:00 PM'},
+                        {value: '12:00 PM', newValue: '11:00 AM'},
+                    ].forEach(({value, newValue}) => {
+                        it(`${withCaretLabel(value, '1'.length)} --- ↓ --- ${withCaretLabel(newValue, '1'.length)}`, () => {
+                            cy.get('@textfield')
+                                .type(value)
+                                .type(`{moveToStart}${'{rightArrow}'.repeat('1'.length)}`)
+                                .type('{downArrow}')
+                                .should('have.value', newValue)
+                                .should('have.a.prop', 'selectionStart', '1'.length)
+                                .should('have.a.prop', 'selectionEnd', '1'.length);
                         });
                     });
                 });
@@ -258,6 +339,75 @@ describe('Time', () => {
                                 .should('have.a.prop', 'selectionStart', caretIndex)
                                 .should('have.a.prop', 'selectionEnd', caretIndex);
                         });
+                    });
+                });
+            });
+
+            describe('step = 3 (wraps 11/12 boundary in one jump)', () => {
+                beforeEach(() => {
+                    cy.visit(`/${DemoPath.Time}/API?mode=HH:MM%20AA&step=3`);
+                    cy.get('#demo-content input')
+                        .should('be.visible')
+                        .first()
+                        .focus()
+                        .clear()
+                        .as('textfield');
+                });
+
+                [
+                    {value: '10:00 AM', newValue: '01:00 PM'},
+                    {value: '10:00 PM', newValue: '01:00 AM'},
+                ].forEach(({value, newValue}) => {
+                    it(`${withCaretLabel(value, '1'.length)} --- ↑ --- ${withCaretLabel(newValue, '1'.length)}`, () => {
+                        cy.get('@textfield')
+                            .type(value)
+                            .type(`{moveToStart}${'{rightArrow}'.repeat('1'.length)}`)
+                            .type('{upArrow}')
+                            .should('have.value', newValue)
+                            .should('have.a.prop', 'selectionStart', '1'.length)
+                            .should('have.a.prop', 'selectionEnd', '1'.length);
+                    });
+                });
+
+                [
+                    {value: '01:00 PM', newValue: '10:00 AM'},
+                    {value: '01:00 AM', newValue: '10:00 PM'},
+                ].forEach(({value, newValue}) => {
+                    it(`${withCaretLabel(value, '1'.length)} --- ↓ --- ${withCaretLabel(newValue, '1'.length)}`, () => {
+                        cy.get('@textfield')
+                            .type(value)
+                            .type(`{moveToStart}${'{rightArrow}'.repeat('1'.length)}`)
+                            .type('{downArrow}')
+                            .should('have.value', newValue)
+                            .should('have.a.prop', 'selectionStart', '1'.length)
+                            .should('have.a.prop', 'selectionEnd', '1'.length);
+                    });
+                });
+            });
+
+            describe('step = 12 (full half-day always flips meridiem)', () => {
+                beforeEach(() => {
+                    cy.visit(`/${DemoPath.Time}/API?mode=HH:MM%20AA&step=12`);
+                    cy.get('#demo-content input')
+                        .should('be.visible')
+                        .first()
+                        .focus()
+                        .clear()
+                        .as('textfield');
+                });
+
+                [
+                    {value: '01:30 AM', newValue: '01:30 PM'},
+                    {value: '12:30 AM', newValue: '12:30 PM'},
+                ].forEach(({value, newValue}) => {
+                    it(`${withCaretLabel(value, '1'.length)} --- ↑ --- ${withCaretLabel(newValue, '1'.length)}`, () => {
+                        cy.get('@textfield')
+                            .type(value)
+                            .type(`{moveToStart}${'{rightArrow}'.repeat('1'.length)}`)
+                            .type('{upArrow}')
+                            .should('have.value', newValue)
+                            .should('have.a.prop', 'selectionStart', '1'.length)
+                            .should('have.a.prop', 'selectionEnd', '1'.length);
                     });
                 });
             });

--- a/projects/kit/src/lib/masks/time/time-mask.ts
+++ b/projects/kit/src/lib/masks/time/time-mask.ts
@@ -71,6 +71,7 @@ export function maskitoTime(params: MaskitoTimeParams): Required<MaskitoOptions>
                 step,
                 timeSegmentMinValues,
                 timeSegmentMaxValues,
+                dayPeriod,
             }),
             createMeridiemSteppingPlugin({
                 dayPeriod,

--- a/projects/kit/src/lib/plugins/time/time-segments-stepping.ts
+++ b/projects/kit/src/lib/plugins/time/time-segments-stepping.ts
@@ -1,15 +1,20 @@
 import {type MaskitoPlugin, maskitoUpdateElement} from '@maskito/core';
 
+import {CHAR_NO_BREAK_SPACE} from '../../constants';
+import {type MaskitoTimeParams} from '../../masks/time';
 import type {MaskitoTimeSegments} from '../../types';
 import {noop} from '../../utils';
+import {createDayPeriodMatchers, hasDayPeriod} from '../../utils/time';
+
+type TimeSegment = keyof MaskitoTimeSegments<number>;
 
 export function createTimeSegmentsSteppingPlugin({
     step,
     fullMode,
     timeSegmentMinValues,
     timeSegmentMaxValues,
-}: {
-    step: number;
+    dayPeriod,
+}: Pick<Required<MaskitoTimeParams>, 'dayPeriod' | 'step'> & {
     fullMode: string;
     timeSegmentMinValues: MaskitoTimeSegments<number>;
     timeSegmentMaxValues: MaskitoTimeSegments<number>;
@@ -25,6 +30,7 @@ export function createTimeSegmentsSteppingPlugin({
                   }
 
                   event.preventDefault();
+
                   const selectionStart = element.selectionStart ?? 0;
 
                   const activeSegment = getActiveSegment({
@@ -36,16 +42,30 @@ export function createTimeSegmentsSteppingPlugin({
                       return;
                   }
 
+                  const toAdd = event.key === 'ArrowUp' ? step : -step;
+                  const selection = segmentsIndexes.get(activeSegment)!;
+                  const meridiem = hasDayPeriod(dayPeriod) ? dayPeriod : null;
+                  const previousValue = element.value;
+
                   const updatedValue = updateSegmentValue({
-                      selection: segmentsIndexes.get(activeSegment)!,
-                      value: element.value,
-                      toAdd: event.key === 'ArrowUp' ? step : -step,
+                      selection,
+                      value: previousValue,
+                      toAdd,
                       min: timeSegmentMinValues[activeSegment],
                       max: timeSegmentMaxValues[activeSegment],
                   });
 
                   maskitoUpdateElement(element, {
-                      value: updatedValue,
+                      value:
+                          meridiem &&
+                          shouldToggleMeridiem({
+                              activeSegment,
+                              previousValue,
+                              selection,
+                              toAdd,
+                          })
+                              ? toggleMeridiem(updatedValue, meridiem)
+                              : updatedValue,
                       selection: [selectionStart, selectionStart],
                   });
               };
@@ -58,7 +78,7 @@ export function createTimeSegmentsSteppingPlugin({
 
 function createTimeSegmentsIndexes(
     fullMode: string,
-): Map<keyof MaskitoTimeSegments, readonly [number, number]> {
+): Map<TimeSegment, readonly [number, number]> {
     return new Map([
         ['hours', getSegmentRange(fullMode, 'HH')],
         ['milliseconds', getSegmentRange(fullMode, 'MSS')],
@@ -77,9 +97,9 @@ function getActiveSegment({
     segmentsIndexes,
     selectionStart,
 }: {
-    segmentsIndexes: Map<keyof MaskitoTimeSegments, readonly [number, number]>;
+    segmentsIndexes: Map<TimeSegment, readonly [number, number]>;
     selectionStart: number;
-}): keyof MaskitoTimeSegments | null {
+}): TimeSegment | null {
     for (const [segmentName, segmentRange] of segmentsIndexes.entries()) {
         const [from, to] = segmentRange;
 
@@ -108,11 +128,61 @@ function updateSegmentValue({
     const segmentValue = Number(value.slice(from, to).padEnd(to - from, '0'));
     const newSegmentValue = mod(segmentValue + toAdd, min, max + 1);
 
-    return `${value.slice(0, from)}${String(newSegmentValue).padStart(to - from, '0')}${value.slice(to, value.length)}`;
+    return `${value.slice(0, from)}${String(newSegmentValue).padStart(
+        to - from,
+        '0',
+    )}${value.slice(to)}`;
 }
 
 function mod(value: number, min: number, max: number): number {
     const range = max - min;
 
     return ((((value - min) % range) + range) % range) + min;
+}
+
+function shouldToggleMeridiem({
+    activeSegment,
+    previousValue,
+    selection,
+    toAdd,
+}: {
+    activeSegment: TimeSegment;
+    previousValue: string;
+    selection: readonly [number, number];
+    toAdd: number;
+}): boolean {
+    if (activeSegment !== 'hours') {
+        return false;
+    }
+
+    const [segmentStart, segmentEnd] = selection;
+    const segmentLength = segmentEnd - segmentStart;
+
+    const previousHour = Number(
+        previousValue.slice(segmentStart, segmentEnd).padEnd(segmentLength, '0'),
+    );
+
+    const dialIndex = previousHour % 12;
+    const wraps = Math.floor((dialIndex + toAdd) / 12);
+
+    return Math.abs(wraps) % 2 === 1;
+}
+
+function toggleMeridiem(
+    value: string,
+    dayPeriod: Required<MaskitoTimeParams>['dayPeriod'],
+): string {
+    const [am, pm] = dayPeriod;
+    const lowerValue = value.toLowerCase();
+    const containsAm = lowerValue.includes(am.toLowerCase());
+    const containsPm = lowerValue.includes(pm.toLowerCase());
+
+    if (!containsAm && !containsPm) {
+        return value;
+    }
+
+    const nextMeridiem = containsAm ? pm : am;
+    const {anyDayPeriodCharRE} = createDayPeriodMatchers(dayPeriod);
+
+    return value.replace(anyDayPeriodCharRE, `${CHAR_NO_BREAK_SPACE}${nextMeridiem}`);
 }


### PR DESCRIPTION
Fixes #2553 

  In 12-hour `Time` mode, stepping the hour segment with `ArrowUp`/`ArrowDown` only changed digits — the `AM`/`PM` marker stayed put. Crossing the 11/12 dial boundary
  should flip the meridiem (since on a 12-hour clock that boundary is exactly the AM↔PM transition).

  ```
  Before:
  1|1:00 AM => ArrowUp => 1|2:00 AM
  1|1:00 PM => ArrowUp => 1|2:00 PM

  After:
  1|1:00 AM => ArrowUp => 1|2:00 PM
  1|1:00 PM => ArrowUp => 1|2:00 AM
  ```
