### PR TITLE
fix(kit): prevent deletion of trailing character on inserting digit before a separator in `Date`/ `DateTime`

### DIFF
--- a/projects/demo-integrations/src/tests/kit/date-time/date-time-basic.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date-time/date-time-basic.cy.ts
@@ -223,6 +223,47 @@ describe('DateTime | Basic', () => {
                 .should('have.prop', 'selectionStart', '12.12.2010, 09:'.length)
                 .should('have.prop', 'selectionEnd', '12.12.2010, 09:'.length);
         });
+
+        describe('cursor right before separator', () => {
+            it('05|.02.2026, 10:25 => Type "1" => 05.1|2.2026, 10:25', () => {
+                cy.get('@input')
+                    .type('050220261025')
+                    .should('have.value', '05.02.2026, 10:25')
+                    .type('{leftArrow}'.repeat('.02.2026, 10:25'.length))
+                    .should('have.prop', 'selectionStart', '05'.length)
+                    .should('have.prop', 'selectionEnd', '05'.length)
+                    .type('1')
+                    .should('have.value', '05.12.2026, 10:25')
+                    .should('have.prop', 'selectionStart', '05.1'.length)
+                    .should('have.prop', 'selectionEnd', '05.1'.length);
+            });
+
+            it('05.12.2026|, 10:25 => Type "5" => 05.12.2026, 05:|25', () => {
+                cy.get('@input')
+                    .type('051220261025')
+                    .should('have.value', '05.12.2026, 10:25')
+                    .type('{leftArrow}'.repeat(', 10:25'.length))
+                    .should('have.prop', 'selectionStart', '05.12.2026'.length)
+                    .should('have.prop', 'selectionEnd', '05.12.2026'.length)
+                    .type('5')
+                    .should('have.value', '05.12.2026, 05:25')
+                    .should('have.prop', 'selectionStart', '05.12.2026, 05:'.length)
+                    .should('have.prop', 'selectionEnd', '05.12.2026, 05:'.length);
+            });
+
+            it('05.12.2026, 10|:25 => Type "5" => 05.12.2026, 10:5|5', () => {
+                cy.get('@input')
+                    .type('051220261025')
+                    .should('have.value', '05.12.2026, 10:25')
+                    .type('{leftArrow}'.repeat(':25'.length))
+                    .should('have.prop', 'selectionStart', '05.12.2026, 10'.length)
+                    .should('have.prop', 'selectionEnd', '05.12.2026, 10'.length)
+                    .type('5')
+                    .should('have.value', '05.12.2026, 10:55')
+                    .should('have.prop', 'selectionStart', '05.12.2026, 10:5'.length)
+                    .should('have.prop', 'selectionEnd', '05.12.2026, 10:5'.length);
+            });
+        });
     });
 
     describe('Text selection', () => {

--- a/projects/demo-integrations/src/tests/kit/date/date-basic.cy.ts
+++ b/projects/demo-integrations/src/tests/kit/date/date-basic.cy.ts
@@ -216,6 +216,34 @@ describe('Date', () => {
                     .should('have.prop', 'selectionStart', '05.'.length)
                     .should('have.prop', 'selectionEnd', '05.'.length);
             });
+
+            describe('cursor right before separator', () => {
+                it('05|.02.2026 => Type "1" => 05.1|2.2026', () => {
+                    cy.get('@input')
+                        .type('05022026')
+                        .should('have.value', '05.02.2026')
+                        .type('{leftArrow}'.repeat('.02.2026'.length))
+                        .should('have.prop', 'selectionStart', '05'.length)
+                        .should('have.prop', 'selectionEnd', '05'.length)
+                        .type('1')
+                        .should('have.value', '05.12.2026')
+                        .should('have.prop', 'selectionStart', '05.1'.length)
+                        .should('have.prop', 'selectionEnd', '05.1'.length);
+                });
+
+                it('05.12|.2026 => Type "5" => 05.12.5|026', () => {
+                    cy.get('@input')
+                        .type('05122026')
+                        .should('have.value', '05.12.2026')
+                        .type('{leftArrow}'.repeat('.2026'.length))
+                        .should('have.prop', 'selectionStart', '05.12'.length)
+                        .should('have.prop', 'selectionEnd', '05.12'.length)
+                        .type('5')
+                        .should('have.value', '05.12.5026')
+                        .should('have.prop', 'selectionStart', '05.12.5'.length)
+                        .should('have.prop', 'selectionEnd', '05.12.5'.length);
+                });
+            });
         });
 
         describe('Fixed values', () => {

--- a/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
+++ b/projects/kit/src/lib/masks/date-time/preprocessors/valid-date-time-preprocessor.ts
@@ -2,6 +2,7 @@ import type {MaskitoPreprocessor} from '@maskito/core';
 
 import type {MaskitoTimeSegments} from '../../../types';
 import {validateDateString} from '../../../utils';
+import {skipNonDigitCharacters} from '../../../utils/skip-non-digit-characters';
 import {enrichTimeSegmentsWithZeroes} from '../../../utils/time';
 import {type MaskitoTimeParams} from '../../time/time-params';
 import {splitDateTimeString} from '../utils';
@@ -35,7 +36,7 @@ export function createValidDateTimePreprocessor({
             return {elementState, data};
         }
 
-        const [from, rawTo] = selection;
+        const [from, rawTo] = skipNonDigitCharacters(value, selection);
         let to = rawTo + data.length;
         const newPossibleValue = `${value.slice(0, from)}${newCharacters}${value.slice(to)}`;
 
@@ -78,7 +79,7 @@ export function createValidDateTimePreprocessor({
 
         return {
             elementState: {
-                selection,
+                selection: [from, rawTo],
                 value: `${validatedValue.slice(0, from)}${newData
                     .split(dateSeparator)
                     .map((segment) => '0'.repeat(segment.length))

--- a/projects/kit/src/lib/processors/valid-date-preprocessor.ts
+++ b/projects/kit/src/lib/processors/valid-date-preprocessor.ts
@@ -1,6 +1,7 @@
 import type {MaskitoPreprocessor} from '@maskito/core';
 
 import {escapeRegExp, parseDateRangeString, validateDateString} from '../utils';
+import {skipNonDigitCharacters} from '../utils/skip-non-digit-characters';
 
 export function createValidDatePreprocessor({
     dateModeTemplate,
@@ -33,7 +34,7 @@ export function createValidDatePreprocessor({
             '',
         );
 
-        const [from, rawTo] = selection;
+        const [from, rawTo] = skipNonDigitCharacters(value, selection);
         let to = rawTo + data.length;
         const newPossibleValue = `${value.slice(0, from)}${newCharacters}${value.slice(to)}`;
 
@@ -73,7 +74,7 @@ export function createValidDatePreprocessor({
 
         return {
             elementState: {
-                selection,
+                selection: [from, rawTo],
                 value: `${validatedValue.slice(0, from)}${newData
                     .split(dateSeparator)
                     .map((segment) => '0'.repeat(segment.length))

--- a/projects/kit/src/lib/utils/skip-non-digit-characters.ts
+++ b/projects/kit/src/lib/utils/skip-non-digit-characters.ts
@@ -1,0 +1,19 @@
+const DIGIT_REGEXP = /\d/;
+const NON_DIGIT_REGEXP = /\D/;
+
+export function skipNonDigitCharacters(
+    value: string,
+    [from, to]: readonly [number, number],
+): readonly [number, number] {
+    if (from !== to || from <= 0 || !DIGIT_REGEXP.test(value.charAt(from - 1))) {
+        return [from, to];
+    }
+
+    let shifted = from;
+
+    while (shifted < value.length && NON_DIGIT_REGEXP.test(value.charAt(shifted))) {
+        shifted++;
+    }
+
+    return [shifted, shifted];
+}

--- a/projects/kit/src/lib/utils/tests/skip-non-digit-characters.spec.ts
+++ b/projects/kit/src/lib/utils/tests/skip-non-digit-characters.spec.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from '@jest/globals';
+
+import {skipNonDigitCharacters} from '../skip-non-digit-characters';
+
+describe('skipNonDigitCharacters', () => {
+    it('returns the original selection when not collapsed', () => {
+        expect(skipNonDigitCharacters('05/13/2026', [2, 5])).toEqual([2, 5]);
+    });
+
+    it('returns the original selection at the start of the value', () => {
+        expect(skipNonDigitCharacters('/13/2026', [0, 0])).toEqual([0, 0]);
+    });
+
+    it('returns the original selection when the value is an empty string', () => {
+        expect(skipNonDigitCharacters('', [0, 0])).toEqual([0, 0]);
+    });
+
+    it('returns the original selection when from/to are out of bounds (negative)', () => {
+        expect(skipNonDigitCharacters('123', [-1, -1])).toEqual([-1, -1]);
+    });
+
+    it('returns the original selection when from/to are out of bounds (too large)', () => {
+        expect(skipNonDigitCharacters('123', [5, 5])).toEqual([5, 5]);
+    });
+
+    it('returns the original selection when preceded by a digit but cursor is on a digit', () => {
+        expect(skipNonDigitCharacters('0513', [2, 2])).toEqual([2, 2]);
+    });
+
+    it('returns the original selection when previous character is not a digit', () => {
+        expect(skipNonDigitCharacters('AA/12', [2, 2])).toEqual([2, 2]);
+    });
+
+    it('returns the original selection when non-digit character is preceded by another non-digit character', () => {
+        expect(skipNonDigitCharacters('05//13', [3, 3])).toEqual([3, 3]);
+    });
+
+    it('shifts past a single non-digit character when preceded by a digit', () => {
+        expect(skipNonDigitCharacters('05/13/2026', [2, 2])).toEqual([3, 3]);
+    });
+
+    it('shifts past multiple consecutive non-digit characters', () => {
+        expect(skipNonDigitCharacters('05/13/2026, 10:25', [10, 10])).toEqual([12, 12]);
+    });
+
+    it('shifts past time segment separator', () => {
+        expect(skipNonDigitCharacters('05/13/2026, 10:25', [14, 14])).toEqual([15, 15]);
+    });
+
+    it('shifts to the end when value ends with non-digit characters', () => {
+        expect(skipNonDigitCharacters('123abc', [3, 3])).toEqual([6, 6]);
+    });
+
+    it('shifts past whitespace characters when they are preceded by a digit', () => {
+        expect(skipNonDigitCharacters('1\t\t2', [1, 1])).toEqual([3, 3]);
+    });
+
+    it('treats any non-digit character after a digit as skippable', () => {
+        expect(skipNonDigitCharacters('12ABC34', [2, 2])).toEqual([5, 5]);
+    });
+});


### PR DESCRIPTION
Fixes #2710
