### PR TITLE
deprecate(phone): use `maskitoPhone` instead of deprecated `maskitoPhoneOptionsGenerator`

### DIFF
--- a/projects/demo-integrations/src/tests/component-testing/phone/phone-national-format.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/phone/phone-national-format.cy.ts
@@ -1,4 +1,4 @@
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import metadata from 'libphonenumber-js/min/metadata';
 
 import {TestInput} from '../utils';
@@ -9,7 +9,7 @@ describe('Phone | National format', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'US',
                             metadata,
                             format: 'NATIONAL',
@@ -43,7 +43,7 @@ describe('Phone | National format', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'US',
                             metadata,
                             format: 'NATIONAL',
@@ -95,7 +95,7 @@ describe('Phone | National format', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'RU',
                             metadata,
                             format: 'NATIONAL',
@@ -129,7 +129,7 @@ describe('Phone | National format', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'RU',
                             metadata,
                             format: 'NATIONAL',
@@ -181,7 +181,7 @@ describe('Phone | National format', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'ES',
                             metadata,
                             format: 'NATIONAL',
@@ -215,7 +215,7 @@ describe('Phone | National format', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'ES',
                             metadata,
                             format: 'NATIONAL',
@@ -267,7 +267,7 @@ describe('Phone | National format', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'FR',
                             metadata,
                             format: 'NATIONAL',
@@ -301,7 +301,7 @@ describe('Phone | National format', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'FR',
                             metadata,
                             format: 'NATIONAL',
@@ -352,7 +352,7 @@ describe('Phone | National format', () => {
         beforeEach(() => {
             cy.mount(TestInput, {
                 componentProperties: {
-                    maskitoOptions: maskitoPhoneOptionsGenerator({
+                    maskitoOptions: maskitoPhone({
                         countryIsoCode: 'US',
                         metadata,
                         format: 'NATIONAL',

--- a/projects/demo-integrations/src/tests/component-testing/phone/phone-with-initial-value.cy.ts
+++ b/projects/demo-integrations/src/tests/component-testing/phone/phone-with-initial-value.cy.ts
@@ -1,5 +1,5 @@
 import type {MaskitoOptions} from '@maskito/core';
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import metadata from 'libphonenumber-js/min/metadata';
 
 import {TestInput} from '../utils';
@@ -8,7 +8,7 @@ describe('Phone | With initial value', () => {
     describe('Strict mode (Kazakhstan)', () => {
         // Create fresh options for each test to ensure clean closure state
         function createMaskitoOptions(): MaskitoOptions {
-            return maskitoPhoneOptionsGenerator({
+            return maskitoPhone({
                 countryIsoCode: 'KZ',
                 metadata,
                 strict: true,
@@ -131,7 +131,7 @@ describe('Phone | With initial value', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'US',
                             metadata,
                             strict: true,
@@ -205,7 +205,7 @@ describe('Phone | With initial value', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'FR',
                             metadata,
                             strict: true,
@@ -279,7 +279,7 @@ describe('Phone | With initial value', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'US',
                             metadata,
                             strict: false,
@@ -338,7 +338,7 @@ describe('Phone | With initial value', () => {
             beforeEach(() => {
                 cy.mount(TestInput, {
                     componentProperties: {
-                        maskitoOptions: maskitoPhoneOptionsGenerator({
+                        maskitoOptions: maskitoPhone({
                             countryIsoCode: 'FR',
                             metadata,
                             strict: false,

--- a/projects/demo/src/pages/documentation/real-world-form/index.ts
+++ b/projects/demo/src/pages/documentation/real-world-form/index.ts
@@ -8,7 +8,7 @@ import {
     maskitoNumber,
     maskitoRemoveOnBlurPlugin,
 } from '@maskito/kit';
-import {maskitoGetCountryFromNumber, maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoGetCountryFromNumber, maskitoPhone} from '@maskito/phone';
 import {isSafari, WA_IS_IOS} from '@ng-web-apis/platform';
 import {tuiInjectElement} from '@taiga-ui/cdk';
 import {TuiButton, TuiIcon, TuiInput, TuiTitle} from '@taiga-ui/core';
@@ -71,7 +71,7 @@ export default class RealWorldForm {
         ],
     };
 
-    protected readonly phoneMask = maskitoPhoneOptionsGenerator({
+    protected readonly phoneMask = maskitoPhone({
         metadata,
         strict: false,
     });

--- a/projects/demo/src/pages/documentation/supported-input-types/examples/tel/mask.ts
+++ b/projects/demo/src/pages/documentation/supported-input-types/examples/tel/mask.ts
@@ -1,7 +1,7 @@
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import metadata from 'libphonenumber-js/metadata.min.json';
 
-export default maskitoPhoneOptionsGenerator({
+export default maskitoPhone({
     metadata,
     countryIsoCode: 'US',
 });

--- a/projects/demo/src/pages/phone/examples/1-basic/mask.ts
+++ b/projects/demo/src/pages/phone/examples/1-basic/mask.ts
@@ -1,4 +1,4 @@
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import metadata from 'libphonenumber-js/min/metadata';
 
-export default maskitoPhoneOptionsGenerator({countryIsoCode: 'KZ', metadata});
+export default maskitoPhone({countryIsoCode: 'KZ', metadata});

--- a/projects/demo/src/pages/phone/examples/2-validation/mask.ts
+++ b/projects/demo/src/pages/phone/examples/2-validation/mask.ts
@@ -1,4 +1,4 @@
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import metadata from 'libphonenumber-js/mobile/metadata';
 
-export default maskitoPhoneOptionsGenerator({countryIsoCode: 'HU', metadata});
+export default maskitoPhone({countryIsoCode: 'HU', metadata});

--- a/projects/demo/src/pages/phone/examples/3-non-strict/mask.ts
+++ b/projects/demo/src/pages/phone/examples/3-non-strict/mask.ts
@@ -1,7 +1,7 @@
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import metadata from 'libphonenumber-js/min/metadata';
 
-export default maskitoPhoneOptionsGenerator({
+export default maskitoPhone({
     metadata,
     strict: false,
     countryIsoCode: 'RU',

--- a/projects/demo/src/pages/phone/examples/4-lazy-metadata/component.ts
+++ b/projects/demo/src/pages/phone/examples/4-lazy-metadata/component.ts
@@ -2,7 +2,7 @@ import {ChangeDetectionStrategy, Component, type OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MaskitoDirective} from '@maskito/angular';
 import {MASKITO_DEFAULT_OPTIONS} from '@maskito/core';
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import {TuiInput} from '@taiga-ui/core';
 
 @Component({
@@ -31,7 +31,7 @@ export class PhoneMaskDocExample4 implements OnInit {
 
     public ngOnInit(): void {
         import('libphonenumber-js/min/metadata').then(({default: metadata}) => () => {
-            this.mask = maskitoPhoneOptionsGenerator({countryIsoCode: 'RU', metadata});
+            this.mask = maskitoPhone({countryIsoCode: 'RU', metadata});
         });
     }
 }

--- a/projects/demo/src/pages/phone/examples/5-focus-blur-events/mask.ts
+++ b/projects/demo/src/pages/phone/examples/5-focus-blur-events/mask.ts
@@ -1,6 +1,6 @@
 import type {MaskitoOptions} from '@maskito/core';
 import {maskitoAddOnFocusPlugin, maskitoRemoveOnBlurPlugin} from '@maskito/kit';
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import {getCountryCallingCode} from 'libphonenumber-js/core';
 import metadata from 'libphonenumber-js/min/metadata';
 
@@ -8,7 +8,7 @@ const countryIsoCode = 'TR';
 const code = getCountryCallingCode(countryIsoCode, metadata);
 const prefix = `+${code} `;
 
-const phoneOptions = maskitoPhoneOptionsGenerator({
+const phoneOptions = maskitoPhone({
     metadata,
     countryIsoCode,
     strict: true,

--- a/projects/demo/src/pages/phone/examples/6-national-format/mask.ts
+++ b/projects/demo/src/pages/phone/examples/6-national-format/mask.ts
@@ -1,4 +1,4 @@
-import {maskitoPhoneOptionsGenerator} from '@maskito/phone';
+import {maskitoPhone} from '@maskito/phone';
 import metadata from 'libphonenumber-js/min/metadata';
 
 /**
@@ -6,7 +6,7 @@ import metadata from 'libphonenumber-js/min/metadata';
  * Displays phone numbers in national format: (XXX) XXX-XXXX
  * without the country code prefix.
  */
-export default maskitoPhoneOptionsGenerator({
+export default maskitoPhone({
     countryIsoCode: 'US',
     metadata,
     format: 'NATIONAL',

--- a/projects/demo/src/pages/phone/phone-doc.component.ts
+++ b/projects/demo/src/pages/phone/phone-doc.component.ts
@@ -4,7 +4,7 @@ import {DocExamplePrimaryTab} from '@demo/constants';
 import {MaskitoDirective} from '@maskito/angular';
 import type {MaskitoOptions} from '@maskito/core';
 import {maskitoAddOnFocusPlugin, maskitoRemoveOnBlurPlugin} from '@maskito/kit';
-import {maskitoPhoneOptionsGenerator, type MaskitoPhoneParams} from '@maskito/phone';
+import {maskitoPhone, type MaskitoPhoneParams} from '@maskito/phone';
 import {isSafari, WA_IS_IOS} from '@ng-web-apis/platform';
 import {TuiAddonDoc, type TuiRawLoaderContent} from '@taiga-ui/addon-doc';
 import {CHAR_PLUS, tuiInjectElement} from '@taiga-ui/cdk';
@@ -32,7 +32,7 @@ const metadataSets = {
     mobile: mobileMetadata,
 } as const satisfies Record<string, MetadataJson>;
 
-type GeneratorOptions = Required<Parameters<typeof maskitoPhoneOptionsGenerator>[0]>;
+type GeneratorOptions = Required<Parameters<typeof maskitoPhone>[0]>;
 
 type MetadataName = keyof typeof metadataSets;
 
@@ -149,7 +149,7 @@ export default class PhoneDocComponent implements GeneratorOptions {
     }
 
     private computeOptions(): Required<MaskitoOptions> {
-        const options = maskitoPhoneOptionsGenerator(this);
+        const options = maskitoPhone(this);
         const code = getCountryCallingCode(this.countryIsoCode, this.metadata);
         const prefix = `${CHAR_PLUS}${code} `;
 

--- a/projects/phone/src/index.ts
+++ b/projects/phone/src/index.ts
@@ -1,2 +1,6 @@
 export type {MaskitoPhoneParams} from './lib/masks';
-export {maskitoGetCountryFromNumber, maskitoPhoneOptionsGenerator} from './lib/masks';
+export {
+    maskitoGetCountryFromNumber,
+    maskitoPhone,
+    maskitoPhoneOptionsGenerator,
+} from './lib/masks';

--- a/projects/phone/src/lib/masks/index.ts
+++ b/projects/phone/src/lib/masks/index.ts
@@ -1,2 +1,6 @@
 export type {MaskitoPhoneParams} from './phone';
-export {maskitoGetCountryFromNumber, maskitoPhoneOptionsGenerator} from './phone';
+export {
+    maskitoGetCountryFromNumber,
+    maskitoPhone,
+    maskitoPhoneOptionsGenerator,
+} from './phone';

--- a/projects/phone/src/lib/masks/phone/index.ts
+++ b/projects/phone/src/lib/masks/phone/index.ts
@@ -1,6 +1,6 @@
 export {TEMPLATE_FILLER} from './constants';
 export type {MaskitoPhoneParams} from './phone-mask';
-export {maskitoPhoneOptionsGenerator} from './phone-mask';
+export {maskitoPhone, maskitoPhoneOptionsGenerator} from './phone-mask';
 export {
     browserAutofillPreprocessorGenerator,
     cutInitCountryCodePreprocessor,

--- a/projects/phone/src/lib/masks/phone/phone-mask.ts
+++ b/projects/phone/src/lib/masks/phone/phone-mask.ts
@@ -18,7 +18,7 @@ export interface MaskitoPhoneParams {
     format?: Extract<NumberFormat, 'INTERNATIONAL' | 'NATIONAL'>;
 }
 
-export function maskitoPhoneOptionsGenerator({
+export function maskitoPhone({
     countryIsoCode,
     metadata,
     strict = true,
@@ -38,3 +38,10 @@ export function maskitoPhoneOptionsGenerator({
               separator,
           });
 }
+
+export {
+    /**
+     * @deprecated Use {@link maskitoPhone} instead.
+     */
+    maskitoPhone as maskitoPhoneOptionsGenerator,
+};

--- a/projects/phone/src/lib/masks/phone/tests/phone-mask.spec.ts
+++ b/projects/phone/src/lib/masks/phone/tests/phone-mask.spec.ts
@@ -6,14 +6,14 @@ import {
 } from '@maskito/core';
 import metadata from 'libphonenumber-js/min/metadata';
 
-import {maskitoPhoneOptionsGenerator} from '../phone-mask';
+import {maskitoPhone} from '../phone-mask';
 
 describe('Phone (maskitoTransform)', () => {
     describe('RU number', () => {
         let options: MaskitoOptions = MASKITO_DEFAULT_OPTIONS;
 
         beforeEach(() => {
-            options = maskitoPhoneOptionsGenerator({
+            options = maskitoPhone({
                 countryIsoCode: 'RU',
                 metadata,
             });
@@ -42,7 +42,7 @@ describe('Phone (maskitoTransform)', () => {
         let options: MaskitoOptions = MASKITO_DEFAULT_OPTIONS;
 
         beforeEach(() => {
-            options = maskitoPhoneOptionsGenerator({
+            options = maskitoPhone({
                 metadata,
                 strict: false,
                 countryIsoCode: 'RU',
@@ -69,7 +69,7 @@ describe('Phone (maskitoTransform)', () => {
             let options: MaskitoOptions = MASKITO_DEFAULT_OPTIONS;
 
             beforeEach(() => {
-                options = maskitoPhoneOptionsGenerator({
+                options = maskitoPhone({
                     countryIsoCode: 'US',
                     metadata,
                     format: 'NATIONAL',
@@ -103,7 +103,7 @@ describe('Phone (maskitoTransform)', () => {
             let options: MaskitoOptions = MASKITO_DEFAULT_OPTIONS;
 
             beforeEach(() => {
-                options = maskitoPhoneOptionsGenerator({
+                options = maskitoPhone({
                     countryIsoCode: 'RU',
                     metadata,
                     format: 'NATIONAL',
@@ -134,7 +134,7 @@ describe('Phone (maskitoTransform)', () => {
             let options: MaskitoOptions = MASKITO_DEFAULT_OPTIONS;
 
             beforeEach(() => {
-                options = maskitoPhoneOptionsGenerator({
+                options = maskitoPhone({
                     countryIsoCode: 'US',
                     metadata,
                     format: 'NATIONAL',


### PR DESCRIPTION
Relates:
- https://github.com/taiga-family/maskito/issues/2645
