### PR TITLE
chore(demo): add RTL recipes for masked placeholders

### DIFF
--- a/projects/demo/src/app/app.routes.ts
+++ b/projects/demo/src/app/app.routes.ts
@@ -164,6 +164,11 @@ export const ROUTES: Routes = [
             import('../pages/recipes/network-address/network-address-doc.component'),
         title: 'Network address',
     },
+    {
+        path: DemoPath.RTL,
+        loadComponent: () => import('../pages/recipes/rtl/rtl-doc.component'),
+        title: 'RTL',
+    },
     // Other
     {
         path: DemoPath.BrowserSupport,

--- a/projects/demo/src/app/constants/demo-path.ts
+++ b/projects/demo/src/app/constants/demo-path.ts
@@ -26,6 +26,7 @@ export const DemoPath = {
     Postfix: 'recipes/postfix',
     Placeholder: 'recipes/placeholder',
     NetworkAddress: 'recipes/network-address',
+    RTL: 'recipes/rtl',
     BrowserSupport: 'browser-support',
     SupportedInputTypes: 'supported-input-types',
     RealWorldForm: 'real-world-form',

--- a/projects/demo/src/pages/pages.ts
+++ b/projects/demo/src/pages/pages.ts
@@ -167,6 +167,12 @@ export const DEMO_PAGES: TuiDocRoutePages = [
         keywords: 'ipv6, ipv4, ip, mac, address, network, recipe',
     },
     {
+        section: 'Recipes',
+        title: 'RTL',
+        route: DemoPath.RTL,
+        keywords: 'RTL',
+    },
+    {
         section: 'Other',
         title: 'Browser support',
         route: DemoPath.BrowserSupport,

--- a/projects/demo/src/pages/recipes/rtl/examples/1-date-placeholder/index.html
+++ b/projects/demo/src/pages/recipes/rtl/examples/1-date-placeholder/index.html
@@ -1,0 +1,14 @@
+<tui-textfield
+    dir="rtl"
+    iconEnd="@tui.calendar"
+    [style.max-width.rem]="20"
+>
+    <label tuiLabel>Enter date</label>
+
+    <input
+        inputmode="numeric"
+        tuiInput
+        [maskito]="maskitoOptions"
+        [(ngModel)]="value"
+    />
+</tui-textfield>

--- a/projects/demo/src/pages/recipes/rtl/examples/1-date-placeholder/index.ts
+++ b/projects/demo/src/pages/recipes/rtl/examples/1-date-placeholder/index.ts
@@ -1,0 +1,17 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MaskitoDirective} from '@maskito/angular';
+import {TuiInput} from '@taiga-ui/core';
+
+import mask from './mask';
+
+@Component({
+    selector: 'rtl-doc-example-1',
+    imports: [FormsModule, MaskitoDirective, TuiInput],
+    templateUrl: './index.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RtlDocExample1 {
+    protected readonly maskitoOptions = mask;
+    protected value = '';
+}

--- a/projects/demo/src/pages/recipes/rtl/examples/1-date-placeholder/mask.ts
+++ b/projects/demo/src/pages/recipes/rtl/examples/1-date-placeholder/mask.ts
@@ -1,0 +1,23 @@
+import type {MaskitoOptions} from '@maskito/core';
+import {maskitoDate, maskitoWithPlaceholder} from '@maskito/kit';
+
+import {maskitoWithBidiIsolation} from './with-bidi-isolation';
+
+const dateOptions = maskitoDate({
+    mode: 'dd/mm/yyyy',
+    separator: '/',
+});
+
+const {plugins, ...placeholderOptions} = maskitoWithPlaceholder('dd/mm/yyyy', true);
+
+const options = {
+    ...dateOptions,
+    plugins: plugins.concat(dateOptions.plugins),
+    preprocessors: [...placeholderOptions.preprocessors, ...dateOptions.preprocessors],
+    postprocessors: [...dateOptions.postprocessors, ...placeholderOptions.postprocessors],
+} satisfies Required<MaskitoOptions>;
+
+export default maskitoWithBidiIsolation(options, {
+    shouldIsolate: (value) =>
+        value !== 'dd/mm/yyyy' && !/^\d{2}\/\d{2}\/\d{4}$/u.test(value),
+});

--- a/projects/demo/src/pages/recipes/rtl/examples/1-date-placeholder/with-bidi-isolation.ts
+++ b/projects/demo/src/pages/recipes/rtl/examples/1-date-placeholder/with-bidi-isolation.ts
@@ -1,0 +1,91 @@
+import type {MaskitoOptions} from '@maskito/core';
+
+const LRM = '\u200E';
+const LRI = '\u2066';
+const PDI = '\u2069';
+const START_MARK = LRM;
+const END_MARK = LRM;
+const BIDI_MARKS_REGEXP = /[\u200E\u2066\u2069]/g;
+
+interface Options {
+    shouldIsolate: (cleanValue: string) => boolean;
+}
+
+export function maskitoWithBidiIsolation(
+    options: MaskitoOptions,
+    {shouldIsolate}: Options,
+): MaskitoOptions {
+    return {
+        ...options,
+        preprocessors: [
+            ({elementState, data}) => {
+                const {value, selection} = elementState;
+
+                return {
+                    elementState: {
+                        value: removeBidiIsolation(value),
+                        selection: [
+                            toCleanSelectionIndex(value, selection[0]),
+                            toCleanSelectionIndex(value, selection[1]),
+                        ],
+                    },
+                    data: removeBidiIsolation(data),
+                };
+            },
+            ...(options.preprocessors ?? []),
+        ],
+        postprocessors: [
+            ...(options.postprocessors ?? []),
+            ({value, selection}) => {
+                const cleanValue = removeBidiIsolation(value);
+
+                const cleanSelection = [
+                    toCleanSelectionIndex(value, selection[0]),
+                    toCleanSelectionIndex(value, selection[1]),
+                ] satisfies [number, number];
+
+                return !cleanValue || !shouldIsolate(cleanValue)
+                    ? {
+                          value: cleanValue,
+                          selection: cleanSelection,
+                      }
+                    : {
+                          value: addBidiIsolation(cleanValue),
+                          selection: [
+                              toIsolatedSelectionIndex(cleanSelection[0]),
+                              toIsolatedSelectionIndex(cleanSelection[1]),
+                          ],
+                      };
+            },
+        ],
+    };
+}
+
+function removeBidiIsolation(value: string): string {
+    return value.replaceAll(BIDI_MARKS_REGEXP, '');
+}
+
+function isBidiMark(char: string): boolean {
+    return char === LRM || char === LRI || char === PDI;
+}
+
+function addBidiIsolation(value: string): string {
+    return value ? `${START_MARK}${value}${END_MARK}` : '';
+}
+
+function toCleanSelectionIndex(value: string, index: number): number {
+    const limit = Math.min(index, value.length);
+    let marksBeforeIndex = 0;
+
+    for (let i = 0; i < limit; i++) {
+        if (isBidiMark(value[i] ?? '')) {
+            marksBeforeIndex++;
+        }
+    }
+
+    return Math.max(limit - marksBeforeIndex, 0);
+}
+
+function toIsolatedSelectionIndex(index: number): number {
+    return index + START_MARK.length;
+}

--- a/projects/demo/src/pages/recipes/rtl/examples/2-phone-placeholder/index.html
+++ b/projects/demo/src/pages/recipes/rtl/examples/2-phone-placeholder/index.html
@@ -1,0 +1,14 @@
+<tui-textfield
+    dir="rtl"
+    iconEnd="@tui.phone"
+    [style.max-width.rem]="20"
+>
+    <label tuiLabel>Enter phone</label>
+
+    <input
+        inputmode="tel"
+        tuiInput
+        [maskito]="maskitoOptions"
+        [(ngModel)]="value"
+    />
+</tui-textfield>

--- a/projects/demo/src/pages/recipes/rtl/examples/2-phone-placeholder/index.ts
+++ b/projects/demo/src/pages/recipes/rtl/examples/2-phone-placeholder/index.ts
@@ -1,0 +1,17 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MaskitoDirective} from '@maskito/angular';
+import {TuiInput} from '@taiga-ui/core';
+
+import mask from './mask';
+
+@Component({
+    selector: 'rtl-doc-example-2',
+    imports: [FormsModule, MaskitoDirective, TuiInput],
+    templateUrl: './index.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RtlDocExample2 {
+    protected readonly maskitoOptions = mask;
+    protected value = '';
+}

--- a/projects/demo/src/pages/recipes/rtl/examples/2-phone-placeholder/mask.ts
+++ b/projects/demo/src/pages/recipes/rtl/examples/2-phone-placeholder/mask.ts
@@ -1,0 +1,35 @@
+import type {MaskitoOptions} from '@maskito/core';
+import {maskitoWithPlaceholder} from '@maskito/kit';
+
+import {maskitoWithBidiIsolation} from '../1-date-placeholder/with-bidi-isolation';
+
+const {plugins, ...placeholderOptions} = maskitoWithPlaceholder('+7 (___) ___-__-__');
+
+const options = {
+    mask: [
+        '+',
+        '7',
+        ' ',
+        '(',
+        /\d/,
+        /\d/,
+        /\d/,
+        ')',
+        ' ',
+        /\d/,
+        /\d/,
+        /\d/,
+        '-',
+        /\d/,
+        /\d/,
+        '-',
+        /\d/,
+        /\d/,
+    ],
+    ...placeholderOptions,
+    plugins,
+} satisfies MaskitoOptions;
+
+export default maskitoWithBidiIsolation(options, {
+    shouldIsolate: (value) => value.length > 0,
+});

--- a/projects/demo/src/pages/recipes/rtl/rtl-doc.component.ts
+++ b/projects/demo/src/pages/recipes/rtl/rtl-doc.component.ts
@@ -1,0 +1,38 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {DocExamplePrimaryTab} from '@demo/constants';
+import {TuiAddonDoc, type TuiRawLoaderContent} from '@taiga-ui/addon-doc';
+
+import {RtlDocExample1} from './examples/1-date-placeholder';
+import {RtlDocExample2} from './examples/2-phone-placeholder';
+
+@Component({
+    selector: 'rtl-doc',
+    imports: [RtlDocExample1, RtlDocExample2, TuiAddonDoc],
+    templateUrl: './rtl-doc.template.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export default class RtlDocComponent {
+    protected readonly datePlaceholderExample1: Record<string, TuiRawLoaderContent> = {
+        HTML: import('./examples/1-date-placeholder/index.html'),
+        [DocExamplePrimaryTab.MaskitoOptions]: import(
+            './examples/1-date-placeholder/mask.ts?raw',
+            {with: {loader: 'text'}}
+        ),
+        'with-bidi-isolation.ts': import(
+            './examples/1-date-placeholder/with-bidi-isolation.ts?raw',
+            {with: {loader: 'text'}}
+        ),
+    };
+
+    protected readonly phonePlaceholderExample2: Record<string, TuiRawLoaderContent> = {
+        HTML: import('./examples/2-phone-placeholder/index.html'),
+        [DocExamplePrimaryTab.MaskitoOptions]: import(
+            './examples/2-phone-placeholder/mask.ts?raw',
+            {with: {loader: 'text'}}
+        ),
+        'with-bidi-isolation.ts': import(
+            './examples/1-date-placeholder/with-bidi-isolation.ts?raw',
+            {with: {loader: 'text'}}
+        ),
+    };
+}

--- a/projects/demo/src/pages/recipes/rtl/rtl-doc.template.html
+++ b/projects/demo/src/pages/recipes/rtl/rtl-doc.template.html
@@ -1,0 +1,59 @@
+<tui-doc-page
+    header="RTL"
+    package="Recipes"
+>
+    <ng-template pageTab>
+        <p>These examples show how masked inputs behave in right-to-left contexts.</p>
+
+        <p>
+            Date and phone masks often mix digits, separators, placeholders, and text. In native
+            <code>dir="rtl"</code>
+            inputs, browsers may visually reorder such values according to bidirectional text rules.
+        </p>
+
+        <p>The actual input value can still be correct, even if the displayed text looks unexpected.</p>
+
+        <p>The examples below show native RTL behavior and possible workarounds.</p>
+
+        <p>
+            Unicode direction marks are used here as an experimental workaround. They can improve the visual order, but
+            may temporarily appear in the raw input value while editing.
+        </p>
+
+        <tui-doc-example
+            heading="Date with placeholder"
+            [content]="datePlaceholderExample1"
+            [description]="dateDescription"
+        >
+            <rtl-doc-example-1 />
+
+            <ng-template #dateDescription>
+                <p>
+                    A date placeholder like
+                    <code>12/mm/yyyy</code>
+                    contains numbers, slashes, and Latin letters. In
+                    <code>dir="rtl"</code>
+                    inputs, browsers may display this mixed-direction text in an unexpected order.
+                </p>
+
+                <p>This example shows the issue and a possible workaround.</p>
+            </ng-template>
+        </tui-doc-example>
+
+        <tui-doc-example
+            heading="Phone with placeholder"
+            [content]="phonePlaceholderExample2"
+            [description]="phoneDescription"
+        >
+            <rtl-doc-example-2 />
+
+            <ng-template #phoneDescription>
+                <p>Phone masks can have the same problem because they mix digits, separators, and placeholder text.</p>
+
+                <p>
+                    This example shows how a phone placeholder behaves in RTL and how the visual order can be improved.
+                </p>
+            </ng-template>
+        </tui-doc-example>
+    </ng-template>
+</tui-doc-page>


### PR DESCRIPTION
Fixes #2219

This PR adds RTL examples for date and phone masks and documents native browser behavior for mixed-direction values. It also shows an experimental workaround based on Unicode direction marks.

### Before


https://github.com/user-attachments/assets/44ad0251-f656-4150-b17f-1a4065283577



### After


https://github.com/user-attachments/assets/be5c92fe-c244-4da9-a603-edc10d6c08fa


