### PR TITLE
fix: use `sideEffects: false` for all packages to optimize tree shaking

### DIFF
--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -43,5 +43,6 @@
             "email": "nextzeddicus@gmail.com",
             "name": "Georgiy Lunin"
         }
-    ]
+    ],
+    "sideEffects": false
 }

--- a/projects/kit/package.json
+++ b/projects/kit/package.json
@@ -44,6 +44,7 @@
             "name": "Georgiy Lunin"
         }
     ],
+    "sideEffects": false,
     "peerDependencies": {
         "@maskito/core": "^5.3.1"
     }

--- a/projects/phone/package.json
+++ b/projects/phone/package.json
@@ -46,6 +46,7 @@
             "name": "Georgiy Lunin"
         }
     ],
+    "sideEffects": false,
     "devDependencies": {
         "libphonenumber-js": "1.13.6"
     },

--- a/projects/react/package.json
+++ b/projects/react/package.json
@@ -43,6 +43,7 @@
             "name": "Georgiy Lunin"
         }
     ],
+    "sideEffects": false,
     "devDependencies": {
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",

--- a/projects/vue/package.json
+++ b/projects/vue/package.json
@@ -43,6 +43,7 @@
             "name": "Georgiy Lunin"
         }
     ],
+    "sideEffects": false,
     "devDependencies": {
         "@vue/test-utils": "2.4.11",
         "@vue/vue3-jest": "29.2.6",


### PR DESCRIPTION
### Preconditions
```
npx @angular/cli@22 new ng-22-sandbox --defaults
```

```
ng add taiga-ui
```

Add this line to `src/app/app.config.ts`:
```ts
import {tuiInputNumberOptionsProvider} from '@taiga-ui/kit';
// [...]
tuiInputNumberOptionsProvider({
  icons: {
    increase: 'plus',
    decrease: 'minus'
  }
}),
```
That's all! No usage of `TuiInputNumber` or maskito library!

### Analyse esbuild bundle
`stats.json` contains
```json
"node_modules/@maskito/core/index.esm.js": {
  "bytesInOutput": 1032
},
"node_modules/@maskito/kit/index.esm.js": {
  "bytesInOutput": 210
},
```
<img width="1181" height="564" alt="demo" src="https://github.com/user-attachments/assets/aba8eb30-1e09-430d-96aa-9a03a9aef7c2" />
<img width="451" height="135" alt="core" src="https://github.com/user-attachments/assets/a07418a3-8f2a-4ce4-affa-20b6fbbafaa1" />

Why `1kb` / `31.6kb` is still present ? 🤔 



### New behavior
A bundler may drop an unused import **only if** it knows the target module has no side effects on evaluation.
`sideEffects: false ` helps to "say" it.
With this flag mentioned lines no more exists in `stats.json`

> P.S. angular builders add this flag automatically