### PR TITLE
chore: add `publishConfig.access: public` to all packages

### DIFF
--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -55,6 +55,9 @@
         "@angular/forms": ">=19.0.0",
         "@maskito/core": "^5.3.1"
     },
+    "publishConfig": {
+        "access": "public"
+    },
     "ng-update": {
         "packageGroup": [
             "@maskito/core",

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -44,5 +44,8 @@
             "name": "Georgiy Lunin"
         }
     ],
-    "sideEffects": false
+    "sideEffects": false,
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/projects/kit/package.json
+++ b/projects/kit/package.json
@@ -47,5 +47,8 @@
     "sideEffects": false,
     "peerDependencies": {
         "@maskito/core": "^5.3.1"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/projects/phone/package.json
+++ b/projects/phone/package.json
@@ -54,5 +54,8 @@
         "@maskito/core": "^5.3.1",
         "@maskito/kit": "^5.3.1",
         "libphonenumber-js": ">=1.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/projects/react-native/package.json
+++ b/projects/react-native/package.json
@@ -43,5 +43,8 @@
         "@maskito/core": "^5.3.1",
         "react": ">=16.8",
         "react-native": ">=0.87.0"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/projects/react/package.json
+++ b/projects/react/package.json
@@ -57,5 +57,8 @@
         "@maskito/core": "^5.3.1",
         "react": ">=16.8",
         "react-dom": ">=16.8"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/projects/vue/package.json
+++ b/projects/vue/package.json
@@ -52,5 +52,8 @@
     "peerDependencies": {
         "@maskito/core": "^5.3.1",
         "vue": ">=3.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }


### PR DESCRIPTION
### Problem
See https://github.com/taiga-family/maskito/actions/runs/31694660531/job/94429575117

```    
✅ > nx run core:publish
✅ > nx run kit:publish
✅ > nx run angular:publish
✅ > nx run react:publish
✅ > nx run vue:publish
✅ > nx run phone:publish
    
✅ > nx run react-native:build
    
❌ > nx run react-native:publish
    > npm publish ./dist/react-native --ignore-scripts
    npm error code E402
    npm error 402 Payment Required - PUT https://registry.npmjs.org/@maskito%2freact-native - You must sign up for private packages
    npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-08-13T11_17_13_831Z-debug-0.log
    Warning: command "npm publish ./dist/react-native --ignore-scripts" exited with non-zero status code::endgroup::
```

### It's expected error
According to [npm spec](https://docs.npmjs.com/cli/v12/commands/npm-access#details):
> Unscoped packages are always public.
> Scoped packages default to restricted


### Why it worked before ?
It was broken after this PR:
- https://github.com/taiga-family/maskito/pull/1666

<img height="300" alt="projectjson" src="https://github.com/user-attachments/assets/07a30c71-331a-4d46-a8ff-a274f1bdbec9" />

<img height="300" alt="publish" src="https://github.com/user-attachments/assets/cc5f789e-9056-41b7-950b-f871262b7c3b" />



