### PR TITLE
chore(demo): add Email recipe

### DIFF
--- a/projects/demo-integrations/src/tests/recipes/email/email.cy.ts
+++ b/projects/demo-integrations/src/tests/recipes/email/email.cy.ts
@@ -1,0 +1,47 @@
+import {DemoPath} from '@demo/constants';
+
+describe('Email', () => {
+    beforeEach(() => {
+        cy.visit(DemoPath.Email);
+        cy.get('#email input')
+            .should('be.visible')
+            .first()
+            .should('have.value', '')
+            .focus()
+            .as('input');
+    });
+
+    it('accepts an email and its intermediate states', () => {
+        cy.get('@input').type('john@').should('have.value', 'john@');
+        cy.get('@input').type('example.com').should('have.value', 'john@example.com');
+    });
+
+    it('strips mailto prefix on paste', () => {
+        cy.get('@input')
+            .paste('mailto:john@example.com')
+            .should('have.value', 'john@example.com');
+    });
+
+    it('rejects at sign as the first character', () => {
+        cy.get('@input').type('@').should('have.value', '');
+    });
+
+    it('rejects the second at sign', () => {
+        cy.get('@input')
+            .type('john@@example.com')
+            .should('have.value', 'john@example.com');
+    });
+
+    it('rejects whitespace', () => {
+        cy.get('@input')
+            .type('john doe@example.com')
+            .should('have.value', 'johndoe@example.com');
+    });
+
+    it('supports editing', () => {
+        cy.get('@input')
+            .type('john@example.com')
+            .type('{backspace}'.repeat(4))
+            .should('have.value', 'john@example');
+    });
+});

--- a/projects/demo/src/app/app.routes.ts
+++ b/projects/demo/src/app/app.routes.ts
@@ -128,6 +128,11 @@ export const ROUTES: Routes = [
         title: 'Card',
     },
     {
+        path: DemoPath.Email,
+        loadComponent: () => import('../pages/recipes/email/email-doc.component'),
+        title: 'Email',
+    },
+    {
         path: DemoPath.Phone,
         loadComponent: () => import('../pages/recipes/phone/phone-doc.component'),
         title: 'Phone',

--- a/projects/demo/src/app/constants/demo-path.ts
+++ b/projects/demo/src/app/constants/demo-path.ts
@@ -20,6 +20,7 @@ export const DemoPath = {
     KitPlugins: 'kit/plugins',
     PhonePackage: 'addons/phone',
     Card: 'recipes/card',
+    Email: 'recipes/email',
     Phone: 'recipes/phone',
     Textarea: 'recipes/textarea',
     ContentEditable: 'recipes/content-editable',

--- a/projects/demo/src/pages/pages.ts
+++ b/projects/demo/src/pages/pages.ts
@@ -132,6 +132,12 @@ export const DEMO_PAGES: TuiDocRoutePages = [
     },
     {
         section: 'Recipes',
+        title: 'Email',
+        route: DemoPath.Email,
+        keywords: 'email, mail, mailto, address, mask, recipe',
+    },
+    {
+        section: 'Recipes',
         title: 'Phone',
         route: DemoPath.Phone,
         keywords: 'phone, mobile, tel, telephone, mask, recipe',

--- a/projects/demo/src/pages/recipes/email/email-doc.component.ts
+++ b/projects/demo/src/pages/recipes/email/email-doc.component.ts
@@ -1,0 +1,19 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {DocExamplePrimaryTab} from '@demo/constants';
+import {TuiAddonDoc, type TuiRawLoaderContent} from '@taiga-ui/addon-doc';
+
+import Example1 from './examples/1-basic/component';
+
+@Component({
+    selector: 'email-doc',
+    imports: [Example1, TuiAddonDoc],
+    templateUrl: './email-doc.template.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export default class EmailDocComponent {
+    protected readonly emailExample1: Record<string, TuiRawLoaderContent> = {
+        [DocExamplePrimaryTab.MaskitoOptions]: import('./examples/1-basic/mask.ts?raw', {
+            with: {loader: 'text'},
+        }),
+    };
+}

--- a/projects/demo/src/pages/recipes/email/email-doc.component.ts
+++ b/projects/demo/src/pages/recipes/email/email-doc.component.ts
@@ -1,16 +1,20 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {DocExamplePrimaryTab} from '@demo/constants';
+import {RouterLink} from '@angular/router';
+import {DemoPath, DocExamplePrimaryTab} from '@demo/constants';
 import {TuiAddonDoc, type TuiRawLoaderContent} from '@taiga-ui/addon-doc';
+import {TuiLink, TuiNotification, TuiTitle} from '@taiga-ui/core';
 
 import Example1 from './examples/1-basic/component';
 
 @Component({
     selector: 'email-doc',
-    imports: [Example1, TuiAddonDoc],
+    imports: [Example1, RouterLink, TuiAddonDoc, TuiLink, TuiNotification, TuiTitle],
     templateUrl: './email-doc.template.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class EmailDocComponent {
+    protected readonly supportedInputTypesDocPage = `/${DemoPath.SupportedInputTypes}`;
+
     protected readonly emailExample1: Record<string, TuiRawLoaderContent> = {
         [DocExamplePrimaryTab.MaskitoOptions]: import('./examples/1-basic/mask.ts?raw', {
             with: {loader: 'text'},

--- a/projects/demo/src/pages/recipes/email/email-doc.template.html
+++ b/projects/demo/src/pages/recipes/email/email-doc.template.html
@@ -7,6 +7,34 @@
             Use a permissive mask to guide email input while leaving final email validation to your form or application.
         </p>
 
+        <p
+            size="m"
+            tuiNotification
+        >
+            <span tuiTitle>
+                <span>
+                    Don't use
+                    <code>&lt;input type="email" /&gt;</code>
+                    with
+                    <strong>Maskito!</strong>
+                </span>
+                <span tuiSubtitle>
+                    See the only
+                    <a
+                        tuiLink
+                        [routerLink]="supportedInputTypesDocPage"
+                    >
+                        supported input types
+                    </a>
+                    .
+                    <code>inputmode="email"</code>
+                    and
+                    <code>autocomplete="email"</code>
+                    remain available.
+                </span>
+            </span>
+        </p>
+
         <tui-doc-example
             id="email"
             heading="Email"
@@ -19,16 +47,10 @@
                 , rejects whitespace and multiple
                 <code>&#64;</code>
                 symbols, and uses a
-                <strong>preprocessor</strong>
+                <strong>postprocessor</strong>
                 to remove the
                 <code>mailto:</code>
-                prefix on paste. It intentionally does not validate a complete email address. Use
-                <code>type="text"</code>
-                with
-                <code>inputmode="email"</code>
-                because Maskito relies on selection APIs that are unavailable for
-                <code>type="email"</code>
-                inputs.
+                prefix. It intentionally does not validate a complete email address.
             </ng-template>
             <email-doc-example-1 />
         </tui-doc-example>

--- a/projects/demo/src/pages/recipes/email/email-doc.template.html
+++ b/projects/demo/src/pages/recipes/email/email-doc.template.html
@@ -1,0 +1,36 @@
+<tui-doc-page
+    header="Email"
+    package="Recipes"
+>
+    <ng-template pageTab>
+        <p class="tui-space_top-0">
+            Use a permissive mask to guide email input while leaving final email validation to your form or application.
+        </p>
+
+        <tui-doc-example
+            id="email"
+            heading="Email"
+            [content]="emailExample1"
+            [description]="emailDescription"
+        >
+            <ng-template #emailDescription>
+                The mask accepts intermediate states such as
+                <code>user&#64;</code>
+                , rejects whitespace and multiple
+                <code>&#64;</code>
+                symbols, and uses a
+                <strong>preprocessor</strong>
+                to remove the
+                <code>mailto:</code>
+                prefix on paste. It intentionally does not validate a complete email address. Use
+                <code>type="text"</code>
+                with
+                <code>inputmode="email"</code>
+                because Maskito relies on selection APIs that are unavailable for
+                <code>type="email"</code>
+                inputs.
+            </ng-template>
+            <email-doc-example-1 />
+        </tui-doc-example>
+    </ng-template>
+</tui-doc-page>

--- a/projects/demo/src/pages/recipes/email/examples/1-basic/component.ts
+++ b/projects/demo/src/pages/recipes/email/examples/1-basic/component.ts
@@ -1,0 +1,29 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MaskitoDirective} from '@maskito/angular';
+import {TuiInput} from '@taiga-ui/core';
+
+import mask from './mask';
+
+@Component({
+    selector: 'email-doc-example-1',
+    imports: [FormsModule, MaskitoDirective, TuiInput],
+    template: `
+        <tui-textfield [style.max-width.rem]="25">
+            <label tuiLabel>Enter email</label>
+            <input
+                autocomplete="email"
+                inputmode="email"
+                type="text"
+                tuiInput
+                [maskito]="maskitoOptions"
+                [(ngModel)]="value"
+            />
+        </tui-textfield>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export default class Example {
+    protected readonly maskitoOptions = mask;
+    protected value = '';
+}

--- a/projects/demo/src/pages/recipes/email/examples/1-basic/mask.ts
+++ b/projects/demo/src/pages/recipes/email/examples/1-basic/mask.ts
@@ -2,10 +2,10 @@ import type {MaskitoOptions} from '@maskito/core';
 
 export default {
     mask: /^(?:|[^@\s]+(?:@[^@\s]*)?)$/,
-    preprocessors: [
-        ({elementState, data}) => ({
-            elementState,
-            data: data.replace(/^mailto:/i, ''),
+    postprocessors: [
+        ({value, selection}) => ({
+            selection,
+            value: value.replace(/^mailto:/i, ''),
         }),
     ],
 } satisfies MaskitoOptions;

--- a/projects/demo/src/pages/recipes/email/examples/1-basic/mask.ts
+++ b/projects/demo/src/pages/recipes/email/examples/1-basic/mask.ts
@@ -1,0 +1,11 @@
+import type {MaskitoOptions} from '@maskito/core';
+
+export default {
+    mask: /^(?:|[^@\s]+(?:@[^@\s]*)?)$/,
+    preprocessors: [
+        ({elementState, data}) => ({
+            elementState,
+            data: data.replace(/^mailto:/i, ''),
+        }),
+    ],
+} satisfies MaskitoOptions;


### PR DESCRIPTION
Fixes #200

## What is the new behavior?

Adds an `Email` recipe that demonstrates a permissive mask for email input.

- accepts intermediate states such as `user@`
- rejects whitespace and multiple `@` symbols
- strips the `mailto:` prefix on paste with a preprocessor
- keeps final email validation outside of the mask
- uses `type="text"` with `inputmode="email"` because Maskito relies on selection APIs unavailable for `type="email"`
- adds Cypress coverage for typing, paste, invalid input, and editing

The recipe intentionally does not try to implement RFC email validation; its purpose is to guide input while allowing natural intermediate states.