### PR TITLE
fix: stabilize the date placeholder in RTL pages

### DIFF
--- a/projects/demo-integrations/src/tests/recipes/placeholder/date.cy.ts
+++ b/projects/demo-integrations/src/tests/recipes/placeholder/date.cy.ts
@@ -91,4 +91,49 @@ describe('Placeholder | Date', () => {
             .should('have.value', '31/1')
             .should('have.ngControlValue', '31/1');
     });
+
+    describe('RTL document direction', () => {
+        beforeEach(() => {
+            cy.get('@input').blur();
+            cy.document().then(({documentElement}) => {
+                documentElement.dir = 'rtl';
+            });
+            cy.get('html').should('have.attr', 'dir', 'rtl');
+            cy.get('@input')
+                .should('have.attr', 'dir', 'ltr')
+                .focus()
+                .should('have.value', 'dd/mm/yyyy')
+                .should('have.prop', 'selectionStart', 0)
+                .should('have.prop', 'selectionEnd', 0);
+        });
+
+        it('Keeps logical date order while typing', () => {
+            const steps = [
+                ['1', '1d/mm/yyyy', 1],
+                ['6', '16/mm/yyyy', '16'.length],
+                ['0', '16/0m/yyyy', '16/0'.length],
+                ['5', '16/05/yyyy', '16/05'.length],
+                ['2', '16/05/2yyy', '16/05/2'.length],
+                ['0', '16/05/20yy', '16/05/20'.length],
+                ['2', '16/05/202y', '16/05/202'.length],
+                ['3', '16/05/2023', '16/05/2023'.length],
+            ] as const;
+
+            steps.forEach(([typed, masked, caretIndex]) => {
+                cy.get('@input')
+                    .type(typed)
+                    .should('have.value', masked)
+                    .should('have.prop', 'selectionStart', caretIndex)
+                    .should('have.prop', 'selectionEnd', caretIndex);
+            });
+        });
+
+        it('Keeps caret after automatically padded date segments', () => {
+            cy.get('@input')
+                .type('39')
+                .should('have.value', '03/09/yyyy')
+                .should('have.prop', 'selectionStart', '03/09'.length)
+                .should('have.prop', 'selectionEnd', '03/09'.length);
+        });
+    });
 });

--- a/projects/demo/src/pages/recipes/placeholder/examples/3-date/component.ts
+++ b/projects/demo/src/pages/recipes/placeholder/examples/3-date/component.ts
@@ -15,6 +15,7 @@ import mask from './mask';
         >
             <label tuiLabel>Enter date</label>
             <input
+                dir="ltr"
                 inputmode="numeric"
                 tuiInput
                 [maskito]="maskitoOptions"


### PR DESCRIPTION
Set the Date recipe's input direction explicitly to LTR so its logical placeholder and numeric date order remain stable while the surrounding page continues to use RTL layout. Keep this behavior local to the recipe rather than changing `maskitoWithPlaceholder` or Maskito core, because the library cannot infer the intended direction of arbitrary consumer placeholders. Extend the existing Date placeholder Cypress suite by switching the document to RTL and verifying the input retains LTR direction, the masked value grows in logical date order, and the caret remains after the entered portion. The Date placeholder recipe inherits `dir="rtl"` from an RTL document even though its generated value combines Latin placeholder letters, separators, and digits. Firefox's bidirectional rendering can therefore reorder the visible segments as the user replaces `dd/mm/yyyy`, making the value appear to jump while typing. The issue supplies a concrete reproduction against the existing demo, and maintainer discussion identifies the mixed non-RTL character stream as the relevant boundary. The bundle records one prior cross-referenced attempt (#2783), but no open competing PR. With the document set to `dir="rtl"`, the Date recipe input exposes an explicit LTR direction while the document itself remains RTL; Focusing the Date input under RTL document direction displays `dd/mm/yyyy` with the caret at index 0; typing successive date digits produces the existing `1d/mm/yyyy` through `16/05/2023` sequence without changing logical order.

Fixes #2219
